### PR TITLE
grammar constrained repl loop

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -44,3 +44,7 @@ tasks:
       # ptcfmt test summary so the pass count is always visible.
       - nix build --no-warn-dirty --no-link ".#checks.{{.SYSTEM}}.ptcfmt"
       - nix log --no-warn-dirty ".#checks.{{.SYSTEM}}.ptcfmt"
+  pi:
+    desc: run pi agent with access to secrets
+    cmd: go-task _infisical-run  ENV=dev PATHS="/ai" CMD="pnpm run pi"
+

--- a/apps/pi/extensions/lisp-repl.ts
+++ b/apps/pi/extensions/lisp-repl.ts
@@ -170,7 +170,36 @@ function stripFences(text: string): string {
 	return m ? m[1] : text.trim();
 }
 
+// Register Fireworks as an OpenAI-compatible provider. Fireworks ships as a
+// built-in pi provider; registering it here replaces its model list with the
+// models we care about and pins the API-key env var. Grammar-based structured
+// output (docs.fireworks.ai/structured-responses/structured-output-grammar-based)
+// is a per-request `response_format` feature, not a provider setting, so it is
+// not configured here.
+function registerFireworks(pi: ExtensionAPI): void {
+	pi.registerProvider("fireworks", {
+		baseUrl: "https://api.fireworks.ai/inference/v1",
+		apiKey: "$FIREWORKS_API_KEY",
+		api: "openai-completions",
+		models: [
+			{
+				id: "accounts/fireworks/models/kimi-k3",
+				name: "Kimi K3",
+				reasoning: false,
+				// Kimi K3 is multimodal — it accepts image_url content parts.
+				input: ["text", "image"],
+				// Pricing unknown for K3; left at zero rather than guessing.
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 262144,
+				maxTokens: 131072,
+			},
+		],
+	});
+}
+
 export default function (pi: ExtensionAPI) {
+	registerFireworks(pi);
+
 	const repl = new LispRepl();
 	let systemPrompt: string | null = null;
 

--- a/apps/pi/extensions/lisp-repl.ts
+++ b/apps/pi/extensions/lisp-repl.ts
@@ -21,6 +21,7 @@ import {
 } from "@earendil-works/pi-coding-agent";
 import { CURSOR_MARKER, Text } from "@earendil-works/pi-tui";
 import { ReplSession } from "@repo/interpreter";
+import { LISP_GRAMMAR } from "@repo/interpreter/grammar.ts";
 
 // Resolve the interpreter package's `src` dir to read the source we embed
 // into the system prompt (the interpreter itself runs via ReplSession above).
@@ -32,6 +33,11 @@ const SRC_DIR = join(
 const LISP_PATH = join(SRC_DIR, "lisp.ts");
 const OUTPUT_TYPE = "lisp-output";
 const CODE_TYPE = "lisp-code";
+
+// The agent runs as a REPL loop: each Lisp answer is evaluated and its result
+// fed back to trigger the next step. The loop ends when the agent calls
+// `(halt)` or after this many steps (a runaway safeguard).
+const MAX_STEPS = 25;
 
 const ESC = String.fromCharCode(27);
 // ANSI color/style sequences, e.g. "\x1b[32m"
@@ -131,6 +137,8 @@ ABSOLUTE RULES:
 2. Every request from the user — questions, greetings, computations, anything — must be answered with Lisp code. Produce the answer as the VALUE of the last expression. Do NOT wrap it in \`print\`/\`princ\`: the REPL already prints the value of every expression. Use \`print\`/\`princ\` only for side-effect output in the middle of a computation.
 3. If something cannot be expressed in Lisp, output a Lisp expression whose value is an explanation string, e.g. "cannot comply".
 4. The REPL session is persistent: functions and variables defined in one message remain available in later messages. Build on previous definitions. Each evaluation result is sent back to you as a message of type ${OUTPUT_TYPE}.
+4a. You run in a LOOP. Emit ONE Lisp form (or a small group), receive its ${OUTPUT_TYPE} result, then you are automatically asked to continue. Use each result to decide the next step: inspect data, branch, retry, build up state — one step at a time. Do not try to do everything in a single message; take a step, look at the result, then take the next.
+4b. When the user's request is FULLY satisfied, call \`(halt)\` to end the loop; return a final value with \`(halt <expr>)\`. Do NOT call \`(halt)\` before the task is complete. The loop also stops automatically after ${MAX_STEPS} steps.
 5. Output complete, balanced expressions only.
 6. Comments are FORBIDDEN. Never include \`;\` comments — the interpreter ignores them and emits a warning. Code must be self-explanatory without comments.
 7. The dialect is Lisptc (a Common-Lisp-like Lisp with macros, lexical scoping, and tail-call optimization). Its complete interpreter source code is given below — it is the authoritative definition of the language semantics, built-in functions, and the prelude. Consult it to know exactly what is available.
@@ -161,6 +169,12 @@ class LispRepl {
 	eval(code: string): string {
 		return dedupePrintedValue(this.session.eval(code.trim()).trim());
 	}
+
+	// Did the just-evaluated program call `(halt)`? The REPL session owns the
+	// `halt` built-in and its flag; this just surfaces it (see message_end).
+	takeHalted(): boolean {
+		return this.session.takeHalted();
+	}
 }
 
 // Occasionally the model wraps its code in a markdown fence despite the
@@ -185,6 +199,9 @@ function registerFireworks(pi: ExtensionAPI): void {
 			{
 				id: "accounts/fireworks/models/kimi-k3",
 				name: "Kimi K3",
+				// Thinking off at the provider level: declaring the model
+				// non-reasoning makes pi clamp its thinking level to off, so no
+				// `:off` CLI suffix is needed.
 				reasoning: false,
 				// Kimi K3 is multimodal — it accepts image_url content parts.
 				input: ["text", "image"],
@@ -200,8 +217,23 @@ function registerFireworks(pi: ExtensionAPI): void {
 export default function (pi: ExtensionAPI) {
 	registerFireworks(pi);
 
+	// Constrain every reply to valid lisptc source via Fireworks grammar-based
+	// structured output. The payload is the OpenAI-compatible request body;
+	// returning it replaces what pi sends over the wire.
+	pi.on("before_provider_request", async (event) => {
+		const payload = event.payload;
+		if (typeof payload !== "object" || payload === null) return;
+		(payload as { response_format?: unknown }).response_format = {
+			type: "grammar",
+			grammar: LISP_GRAMMAR,
+		};
+		return payload;
+	});
+
 	const repl = new LispRepl();
 	let systemPrompt: string | null = null;
+	// Steps taken in the current REPL loop; reset when a new user task arrives.
+	let steps = 0;
 
 	pi.on("session_start", async (_event, ctx) => {
 		// The agent has no tools at all — its text output IS the Lisp program.
@@ -266,10 +298,18 @@ export default function (pi: ExtensionAPI) {
 		else setTimeout(() => sendWhenIdle(ctx, message), 50);
 	}
 
-	// Everything the agent says is a Lisp program: evaluate it and inject
-	// the REPL output back into the session (displayed below the code with
-	// its own background, and part of the agent's context).
+	// The agent has no tools and its answer is grammar-constrained to lisptc, so
+	// the assistant's text IS a Lisp program: eval it and inject the REPL output
+	// back into the session. Only the `text` parts are the grammar-constrained
+	// answer; Kimi's reasoning arrives as separate `thinking` parts the grammar
+	// cannot reach (Fireworks exposes no switch to disable it on the OpenAI-
+	// compatible endpoint), so those are excluded from eval and dropped from the
+	// transcript rather than fed to the REPL as non-Lisp prose.
 	pi.on("message_end", async (event, ctx) => {
+		const msg = event.message as { role: string; customType?: string };
+		// A genuine user prompt (not one of our injected results) starts a new
+		// task — reset the step budget so each request gets a fresh loop.
+		if (msg.role === "user" && msg.customType === undefined) steps = 0;
 		if (event.message.role !== "assistant") return;
 		const code = event.message.content
 			.filter((c): c is { type: "text"; text: string } => c.type === "text")
@@ -279,20 +319,38 @@ export default function (pi: ExtensionAPI) {
 		if (trimmed === "") return;
 
 		const { output, error } = evalCode(trimmed);
-		sendWhenIdle(ctx, {
+		steps += 1;
+
+		// Drive the loop: unless the agent asked to stop with `(halt)` or we hit
+		// the step cap, feed the result back WITH `triggerTurn` so the agent
+		// runs again and emits the next step. Otherwise just display the result.
+		const halted = repl.takeHalted();
+		const keepLooping = !halted && steps < MAX_STEPS;
+		const resultMessage = {
 			customType: OUTPUT_TYPE,
 			content: output || "(no output)",
 			display: true,
 			details: { code: trimmed, output, error },
-		});
+		};
+		if (keepLooping) {
+			pi.sendMessage(resultMessage, { triggerTurn: true });
+		} else {
+			sendWhenIdle(ctx, resultMessage);
+			if (!halted && steps >= MAX_STEPS)
+				ctx.ui.notify(`Lisp loop stopped after ${MAX_STEPS} steps`, "warning");
+		}
 
 		// Re-fence the code as ```lisp so the default markdown renderer
-		// shows it syntax-highlighted instead of as plain prose.
+		// shows it syntax-highlighted instead of as plain prose. Drop the
+		// original text/thinking parts (folded into `trimmed`); keep anything
+		// else (e.g. images) untouched.
 		return {
 			message: {
 				...event.message,
 				content: [
-					...event.message.content.filter((c) => c.type !== "text"),
+					...event.message.content.filter(
+						(c) => c.type !== "text" && c.type !== "thinking",
+					),
 					{
 						type: "text" as const,
 						text: `\`\`\`lisp\n${trimmed}\n\`\`\``,

--- a/knip.json
+++ b/knip.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
+  "ignoreBinaries": ["pi"],
   "workspaces": {
     "packages/interpreter": {
       "entry": ["test/**/*.test.ts"],

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "biome ci",
     "format": "biome check --write",
     "knip": "knip",
+    "pi": "pi --provider fireworks --model kimi-k3",
     "prepare": "husky"
   },
   "pi": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "biome ci",
     "format": "biome check --write",
     "knip": "knip",
-    "pi": "pi --provider fireworks --model kimi-k3",
+    "pi": "pi --provider fireworks --model kimi-k3:off",
     "prepare": "husky"
   },
   "pi": {

--- a/packages/interpreter/package.json
+++ b/packages/interpreter/package.json
@@ -6,6 +6,7 @@
   "exports": {
     ".": "./src/lisp.ts",
     "./lisp.ts": "./src/lisp.ts",
+    "./grammar.ts": "./src/grammar.ts",
     "./arith.ts": "./src/arith.ts",
     "./mcp.ts": "./src/mcp.ts",
     "./mcp-broker.ts": "./src/mcp-broker.ts",

--- a/packages/interpreter/src/grammar.ts
+++ b/packages/interpreter/src/grammar.ts
@@ -1,0 +1,6 @@
+import { readFileSync } from "node:fs";
+
+export const LISP_GRAMMAR: string = readFileSync(
+	new URL("./lisptc.gbnf", import.meta.url),
+	"utf8",
+);

--- a/packages/interpreter/src/lisp.ts
+++ b/packages/interpreter/src/lisp.ts
@@ -1660,6 +1660,10 @@ export function checkSyntax(text: string): SyntaxError_[] {
 // rendered inline). Lets embedders run Lisp without spawning a subprocess.
 export class ReplSession {
 	private interp: Interp;
+	// Set by the `halt` built-in this session installs; read (and cleared) via
+	// takeHalted(). `halt` is a REPL feature, not part of the interpreter
+	// language — a driver looping over eval() uses it to know when to stop.
+	private halted = false;
 
 	constructor() {
 		this.interp = this.freshInterp();
@@ -1668,7 +1672,23 @@ export class ReplSession {
 	private freshInterp(): Interp {
 		const interp = new Interp();
 		run(interp, prelude);
+		this.installHalt(interp);
 		return interp;
+	}
+
+	// Install `(halt [value])`: record that the program asked to stop and return
+	// `value` (or t). It only sets a flag — evaluation of any following forms
+	// continues — so it is meant as the final form of a program.
+	private installHalt(interp: Interp): void {
+		const halt = interp.makeBuiltIn("halt", -1, (frame) => {
+			this.halted = true;
+			const rest = frame[0] as List;
+			return rest === null ? true : rest.car;
+		});
+		interp.defineGlobal(newSym("halt"), halt, {
+			signature: "(halt [value])",
+			doc: "Signal the REPL to stop after this program; return `value` (or t).",
+		});
 	}
 
 	// Evaluate a program; state persists across calls. Lisp errors are rendered
@@ -1697,6 +1717,15 @@ export class ReplSession {
 	// Discard all definitions; start from a fresh prelude-loaded interp.
 	reset(): void {
 		this.interp = this.freshInterp();
+		this.halted = false;
+	}
+
+	// Whether the last-evaluated program called `(halt)`; reads and clears the
+	// flag so each check reflects only evaluations since the previous check.
+	takeHalted(): boolean {
+		const h = this.halted;
+		this.halted = false;
+		return h;
 	}
 }
 

--- a/packages/interpreter/src/lisptc.gbnf
+++ b/packages/interpreter/src/lisptc.gbnf
@@ -1,0 +1,29 @@
+# GBNF grammar for the lisptc (.ptc) Lisp dialect.
+# Derived from the reader in packages/interpreter/src/lisp.ts, whose tokeniser is
+#   /\s+|;.*$|("(\\.?|.)*?"|,@?|[^()'`~"; \t]+|.)/g
+# Comments (;) are intentionally omitted: the REPL forbids them.
+
+root    ::= ws form (ws form)* ws
+
+form    ::= list | quoted | string | atom
+
+# Reader macros: 'x  `x  ,x  ,@x
+quoted  ::= (",@" | "'" | "`" | ",") ws form
+
+# Proper or dotted list: (a b c) or (a b . c)
+list    ::= "(" ws (form ws)* ("." ws form ws)? ")"
+
+# Symbols, numbers (int/bigint/float), keywords (:kw), nil and t all share one
+# lexical class: a run of any char except whitespace, the structural chars
+# ( ) " ; the quote chars ' ` , and ~. A lone "." is excluded — the reader only
+# ever treats a bare "." as the dotted-pair marker, never as a symbol — while
+# atoms that merely contain "." (e.g. .30, 3.14, fs/read) stay valid.
+atom    ::= hchar achar* | "." achar+
+hchar   ::= [^ \t\r\n()'\"`;,~.]
+achar   ::= [^ \t\r\n()'\"`;,~]
+
+# Double-quoted string with backslash escapes.
+string  ::= "\"" schar* "\""
+schar   ::= [^\"\\] | "\\" .
+
+ws      ::= [ \t\r\n]*

--- a/packages/interpreter/test/emoji.gbnf
+++ b/packages/interpreter/test/emoji.gbnf
@@ -1,0 +1,2 @@
+root  ::= emoji (" "? emoji)*
+emoji ::= [\U0001F300-\U0001FAFF] | [\U00002600-\U000027BF] | [\U0001F1E6-\U0001F1FF]

--- a/packages/interpreter/test/gbnf.ts
+++ b/packages/interpreter/test/gbnf.ts
@@ -1,0 +1,347 @@
+// A small GBNF (llama.cpp / Fireworks flavour) recogniser, used by the tests to
+// check that a `.gbnf` grammar accepts / rejects a given string. It supports the
+// subset the project's grammars use: rules (`name ::= …`), alternation `|`,
+// sequencing, postfix `* + ?`, grouping `( … )`, string literals, character
+// classes (with `^` negation, ranges and `\t \r \n \" \\ \uXXXX \UXXXXXXXX \xXX`
+// escapes) and the `.` any-char wildcard. Matching is over Unicode code points,
+// so astral characters (e.g. emoji) count as one.
+
+type Node =
+	| { t: "ref"; id: number; name: string }
+	| { t: "seq"; id: number; items: Node[] }
+	| { t: "alt"; id: number; opts: Node[] }
+	| { t: "star"; id: number; node: Node }
+	| { t: "plus"; id: number; node: Node }
+	| { t: "opt"; id: number; node: Node }
+	| { t: "lit"; id: number; cps: number[] }
+	| { t: "class"; id: number; neg: boolean; ranges: [number, number][] }
+	| { t: "any"; id: number };
+
+export interface Grammar {
+	rules: Map<string, Node>;
+	start: string;
+}
+
+type Tok =
+	| { k: "name"; v: string }
+	| { k: "def" }
+	| { k: "|" }
+	| { k: "(" }
+	| { k: ")" }
+	| { k: "*" }
+	| { k: "+" }
+	| { k: "?" }
+	| { k: "." }
+	| { k: "str"; cps: number[] }
+	| { k: "class"; neg: boolean; ranges: [number, number][] };
+
+const HEX = (s: string) => Number.parseInt(s, 16);
+
+// Decode one backslash escape starting at `s[i]` (which is the char after `\`).
+// Returns [codePoint, nextIndex].
+function decodeEscape(s: string, i: number): [number, number] {
+	const c = s[i];
+	const simple: Record<string, number> = {
+		n: 10,
+		r: 13,
+		t: 9,
+		f: 12,
+		b: 8,
+		"0": 0,
+		"\\": 92,
+		'"': 34,
+		"'": 39,
+		"]": 93,
+		"[": 91,
+		"-": 45,
+		".": 46,
+		"`": 96,
+	};
+	if (c === "u") return [HEX(s.slice(i + 1, i + 5)), i + 5];
+	if (c === "U") return [HEX(s.slice(i + 1, i + 9)), i + 9];
+	if (c === "x") return [HEX(s.slice(i + 1, i + 3)), i + 3];
+	if (c in simple) return [simple[c], i + 1];
+	return [c.codePointAt(0) as number, i + 1];
+}
+
+function tokenize(src: string): Tok[] {
+	const toks: Tok[] = [];
+	let i = 0;
+	while (i < src.length) {
+		const c = src[i];
+		if (c === " " || c === "\t" || c === "\r" || c === "\n") {
+			i++;
+			continue;
+		}
+		if (c === "#") {
+			while (i < src.length && src[i] !== "\n") i++;
+			continue;
+		}
+		if (c === ":") {
+			if (src.slice(i, i + 3) !== "::=")
+				throw new Error(`expected ::= at ${i}`);
+			toks.push({ k: "def" });
+			i += 3;
+			continue;
+		}
+		if (
+			c === "|" ||
+			c === "(" ||
+			c === ")" ||
+			c === "*" ||
+			c === "+" ||
+			c === "?"
+		) {
+			toks.push({ k: c } as Tok);
+			i++;
+			continue;
+		}
+		if (c === ".") {
+			toks.push({ k: "." });
+			i++;
+			continue;
+		}
+		if (c === '"') {
+			const cps: number[] = [];
+			i++;
+			while (i < src.length && src[i] !== '"') {
+				if (src[i] === "\\") {
+					const [cp, ni] = decodeEscape(src, i + 1);
+					cps.push(cp);
+					i = ni;
+				} else {
+					const cp = src.codePointAt(i) as number;
+					cps.push(cp);
+					i += cp > 0xffff ? 2 : 1;
+				}
+			}
+			if (src[i] !== '"') throw new Error("unterminated string literal");
+			i++;
+			toks.push({ k: "str", cps });
+			continue;
+		}
+		if (c === "[") {
+			i++;
+			let neg = false;
+			if (src[i] === "^") {
+				neg = true;
+				i++;
+			}
+			const ranges: [number, number][] = [];
+			while (i < src.length && src[i] !== "]") {
+				let lo: number;
+				if (src[i] === "\\") {
+					const [cp, ni] = decodeEscape(src, i + 1);
+					lo = cp;
+					i = ni;
+				} else {
+					lo = src.codePointAt(i) as number;
+					i += lo > 0xffff ? 2 : 1;
+				}
+				let hi = lo;
+				if (src[i] === "-" && src[i + 1] !== "]") {
+					i++;
+					if (src[i] === "\\") {
+						const [cp, ni] = decodeEscape(src, i + 1);
+						hi = cp;
+						i = ni;
+					} else {
+						hi = src.codePointAt(i) as number;
+						i += hi > 0xffff ? 2 : 1;
+					}
+				}
+				ranges.push([lo, hi]);
+			}
+			if (src[i] !== "]") throw new Error("unterminated character class");
+			i++;
+			toks.push({ k: "class", neg, ranges });
+			continue;
+		}
+		if (/[A-Za-z0-9_-]/.test(c)) {
+			let j = i;
+			while (j < src.length && /[A-Za-z0-9_-]/.test(src[j])) j++;
+			toks.push({ k: "name", v: src.slice(i, j) });
+			i = j;
+			continue;
+		}
+		throw new Error(`unexpected char ${JSON.stringify(c)} at ${i}`);
+	}
+	return toks;
+}
+
+export function parseGrammar(src: string): Grammar {
+	const toks = tokenize(src);
+	let p = 0;
+	let nextId = 0;
+	const id = () => nextId++;
+	const peek = () => toks[p];
+	const rules = new Map<string, Node>();
+	let start: string | undefined;
+
+	const parseExpr = (): Node => {
+		const opts = [parseSeq()];
+		while (peek()?.k === "|") {
+			p++;
+			opts.push(parseSeq());
+		}
+		return opts.length === 1 ? opts[0] : { t: "alt", id: id(), opts };
+	};
+
+	const parseSeq = (): Node => {
+		const items: Node[] = [];
+		for (;;) {
+			const t = peek();
+			if (!t || t.k === "|" || t.k === ")") break;
+			// A `name ::=` ahead starts the next rule — stop this sequence.
+			if (t.k === "name" && toks[p + 1]?.k === "def") break;
+			items.push(parsePostfix());
+		}
+		if (items.length === 0) throw new Error("empty sequence");
+		return items.length === 1 ? items[0] : { t: "seq", id: id(), items };
+	};
+
+	const parsePostfix = (): Node => {
+		let node = parsePrimary();
+		const t = peek();
+		if (t?.k === "*") {
+			p++;
+			node = { t: "star", id: id(), node };
+		} else if (t?.k === "+") {
+			p++;
+			node = { t: "plus", id: id(), node };
+		} else if (t?.k === "?") {
+			p++;
+			node = { t: "opt", id: id(), node };
+		}
+		return node;
+	};
+
+	const parsePrimary = (): Node => {
+		const t = peek();
+		if (!t) throw new Error("unexpected end of grammar");
+		if (t.k === "(") {
+			p++;
+			const e = parseExpr();
+			if (peek()?.k !== ")") throw new Error("expected )");
+			p++;
+			return e;
+		}
+		if (t.k === "str") {
+			p++;
+			return { t: "lit", id: id(), cps: t.cps };
+		}
+		if (t.k === "class") {
+			p++;
+			return { t: "class", id: id(), neg: t.neg, ranges: t.ranges };
+		}
+		if (t.k === ".") {
+			p++;
+			return { t: "any", id: id() };
+		}
+		if (t.k === "name") {
+			p++;
+			return { t: "ref", id: id(), name: t.v };
+		}
+		throw new Error(`unexpected token ${t.k}`);
+	};
+
+	while (p < toks.length) {
+		const nameTok = peek();
+		if (nameTok?.k !== "name") throw new Error("expected rule name");
+		p++;
+		if (peek()?.k !== "def") throw new Error("expected ::=");
+		p++;
+		const body = parseExpr();
+		rules.set(nameTok.v, body);
+		if (start === undefined) start = nameTok.v;
+	}
+	if (start === undefined) throw new Error("empty grammar");
+	if (rules.has("root")) start = "root";
+	return { rules, start };
+}
+
+// Return the set of end positions reachable by matching `node` at `pos`.
+function matcher(g: Grammar, cps: number[]) {
+	const memo = new Map<string, Set<number>>();
+
+	const match = (node: Node, pos: number): Set<number> => {
+		const key = `${node.id}:${pos}`;
+		const cached = memo.get(key);
+		if (cached) return cached;
+		// Guard against left-recursive cycles (our grammars have none, but be safe).
+		memo.set(key, new Set());
+		const out = compute(node, pos);
+		memo.set(key, out);
+		return out;
+	};
+
+	const compute = (node: Node, pos: number): Set<number> => {
+		switch (node.t) {
+			case "ref": {
+				const rule = g.rules.get(node.name);
+				if (!rule) throw new Error(`undefined rule ${node.name}`);
+				return match(rule, pos);
+			}
+			case "lit": {
+				for (let k = 0; k < node.cps.length; k++) {
+					if (cps[pos + k] !== node.cps[k]) return new Set();
+				}
+				return new Set([pos + node.cps.length]);
+			}
+			case "any":
+				return pos < cps.length ? new Set([pos + 1]) : new Set();
+			case "class": {
+				if (pos >= cps.length) return new Set();
+				const cp = cps[pos];
+				const inRange = node.ranges.some(([lo, hi]) => cp >= lo && cp <= hi);
+				return inRange !== node.neg ? new Set([pos + 1]) : new Set();
+			}
+			case "alt": {
+				const out = new Set<number>();
+				for (const o of node.opts) for (const e of match(o, pos)) out.add(e);
+				return out;
+			}
+			case "seq": {
+				let frontier = new Set([pos]);
+				for (const item of node.items) {
+					const next = new Set<number>();
+					for (const f of frontier) for (const e of match(item, f)) next.add(e);
+					if (next.size === 0) return new Set();
+					frontier = next;
+				}
+				return frontier;
+			}
+			case "opt": {
+				const out = match(node.node, pos);
+				out.add(pos);
+				return out;
+			}
+			case "star":
+			case "plus": {
+				const seen = new Set<number>();
+				const work = [...match(node.node, pos)];
+				for (const e of work) seen.add(e);
+				while (work.length) {
+					const cur = work.pop() as number;
+					for (const e of match(node.node, cur)) {
+						if (!seen.has(e)) {
+							seen.add(e);
+							work.push(e);
+						}
+					}
+				}
+				if (node.t === "star") seen.add(pos);
+				return seen;
+			}
+		}
+	};
+
+	return (node: Node, pos: number) => match(node, pos);
+}
+
+/** Does `grammar` accept the whole of `input`? */
+export function accepts(g: Grammar, input: string): boolean {
+	const cps = Array.from(input, (ch) => ch.codePointAt(0) as number);
+	const run = matcher(g, cps);
+	return run({ t: "ref", id: -1, name: g.start }, 0).has(cps.length);
+}

--- a/packages/interpreter/test/grammar.test.ts
+++ b/packages/interpreter/test/grammar.test.ts
@@ -1,0 +1,57 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+import { LISP_GRAMMAR } from "../src/grammar.ts";
+import { accepts, parseGrammar } from "./gbnf.ts";
+
+describe("lisptc GBNF grammar", () => {
+	const g = parseGrammar(LISP_GRAMMAR);
+
+	const valid = [
+		"(+ 1 2 3 4 5)",
+		"(print (fact 20))",
+		"(defun adder (n) (lambda (x) (+ x n)))",
+		"(< 1 2 3)",
+		"(expt 2 100)",
+		"'((alice .30) (bob .25) (carol .35))",
+		"`(cond ((not ,test) ,@body))",
+		'(load-mcp :name "fs" :command "npx" :args \'("-y" "/tmp"))',
+		'(fs/echo :message "hello from lisptc")',
+		'"a string with \\" an escaped quote"',
+		"(setq x 1)\n(print x)",
+		"'(1 . 2)",
+		"nil",
+		"t",
+		"-3.5e10",
+	];
+	it.each(valid)("accepts %j", (src) => {
+		expect(accepts(g, src)).toBe(true);
+	});
+
+	const invalid = [
+		"", // programs need at least one form
+		"(", // unbalanced
+		")", // stray close
+		"(+ 1 2", // unterminated list
+		"foo)", // trailing close
+		'"unterminated', // open string
+		"'", // quote with nothing to quote
+		"(a . )", // dotted pair with no tail
+	];
+	it.each(invalid)("rejects %j", (src) => {
+		expect(accepts(g, src)).toBe(false);
+	});
+});
+
+describe("emoji GBNF grammar (test fixture)", () => {
+	const g = parseGrammar(
+		readFileSync(new URL("./emoji.gbnf", import.meta.url), "utf8"),
+	);
+
+	it.each(["😀", "🚀🌟", "🎉 🎊", "👍👀🔥"])("accepts %j", (src) => {
+		expect(accepts(g, src)).toBe(true);
+	});
+
+	it.each(["", "hi", "abc", "😀x", "hello 😀"])("rejects %j", (src) => {
+		expect(accepts(g, src)).toBe(false);
+	});
+});

--- a/packages/interpreter/test/repl-session.test.ts
+++ b/packages/interpreter/test/repl-session.test.ts
@@ -34,4 +34,44 @@ describe("ReplSession (in-process REPL binding)", () => {
 		r.reset();
 		expect(r.eval("sq")).toContain("void variable");
 	});
+
+	describe("halt", () => {
+		it("(halt) returns t and raises the halted flag", () => {
+			const r = new ReplSession();
+			expect(r.eval("(halt)")).toBe("t\n");
+			expect(r.takeHalted()).toBe(true);
+		});
+
+		it("(halt value) returns the value", () => {
+			const r = new ReplSession();
+			expect(r.eval("(halt 42)")).toBe("42\n");
+			expect(r.takeHalted()).toBe(true);
+		});
+
+		it("takeHalted() clears the flag after reading", () => {
+			const r = new ReplSession();
+			r.eval("(halt)");
+			expect(r.takeHalted()).toBe(true);
+			expect(r.takeHalted()).toBe(false);
+		});
+
+		it("is false when no (halt) was evaluated", () => {
+			const r = new ReplSession();
+			r.eval("(+ 1 2)");
+			expect(r.takeHalted()).toBe(false);
+		});
+
+		it("only sets the flag when the (halt) branch actually runs", () => {
+			const r = new ReplSession();
+			r.eval("(if nil (halt) 1)");
+			expect(r.takeHalted()).toBe(false);
+		});
+
+		it("reset() clears a raised halted flag", () => {
+			const r = new ReplSession();
+			r.eval("(halt)");
+			r.reset();
+			expect(r.takeHalted()).toBe(false);
+		});
+	});
 });


### PR DESCRIPTION
- **feat: add fireworks api**
- **feat(interpreter): add GBNF grammar for the lisptc dialect**
- **feat(interpreter): add halt built-in to the REPL session**
- **feat(extension): drive a grammar-constrained REPL loop in pi**
closes #10 
