### PR TITLE
feat(interpreter): add secret registry (PTC-12)

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -14,22 +14,9 @@ tasks:
     vars:
       DIR: '{{.DIR | default "."}}'
     cmd: |
-      set -eu
-      # `infisical run --path` takes a single folder (the last flag wins), so to
-      # pull from several paths we export each one to dotenv, merge them into the
-      # environment, then exec the command. Later paths override earlier keys.
-      env_file="$(mktemp)"
-      trap 'rm -f "$env_file"' EXIT
-      for p in {{.PATHS}}; do
-        infisical export -e {{.ENV}} \
-          --projectId={{.PROJECTID}} \
-          --path="$p" --format=dotenv >> "$env_file"
-      done
-      cd {{.DIR}}
-      set -a
-      . "$env_file"
-      set +a
-      exec {{.CMD}}
+      pnpm tsx ./scripts/infisical-run.ts -e {{.ENV}} \
+       --projectId={{.PROJECTID}} \
+       --paths="{{.PATHS}}" --dir={{.DIR}} "{{.CMD}}"
 
   test:
     desc: run all tests (interpreter + nix flake checks)

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -15,13 +15,21 @@ tasks:
       DIR: '{{.DIR | default "."}}'
     cmd: |
       set -eu
-      path_flags=""
+      # `infisical run --path` takes a single folder (the last flag wins), so to
+      # pull from several paths we export each one to dotenv, merge them into the
+      # environment, then exec the command. Later paths override earlier keys.
+      env_file="$(mktemp)"
+      trap 'rm -f "$env_file"' EXIT
       for p in {{.PATHS}}; do
-        path_flags="$path_flags --path=$p"
+        infisical export -e {{.ENV}} \
+          --projectId={{.PROJECTID}} \
+          --path="$p" --format=dotenv >> "$env_file"
       done
-      cd {{.DIR}} && infisical run -e {{.ENV}} \
-        --projectId={{.PROJECTID}} \
-        $path_flags -- {{.CMD}}
+      cd {{.DIR}}
+      set -a
+      . "$env_file"
+      set +a
+      exec {{.CMD}}
 
   test:
     desc: run all tests (interpreter + nix flake checks)
@@ -46,5 +54,8 @@ tasks:
       - nix log --no-warn-dirty ".#checks.{{.SYSTEM}}.ptcfmt"
   pi:
     desc: run pi agent with access to secrets
-    cmd: go-task _infisical-run  ENV=dev PATHS="/ai /repl" CMD="pnpm run pi"
+    cmd: go-task _infisical-run ENV=dev PATHS="/ai /repl" CMD="pnpm run pi"
 
+  test-env:
+    desc: run pi agent with access to secrets
+    cmd: go-task _infisical-run ENV=dev PATHS="/ai /repl" CMD="printenv"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -42,7 +42,3 @@ tasks:
   pi:
     desc: run pi agent with access to secrets
     cmd: go-task _infisical-run ENV=dev PATHS="/ai /repl" CMD="pnpm run pi"
-
-  test-env:
-    desc: run pi agent with access to secrets
-    cmd: go-task _infisical-run ENV=dev PATHS="/ai /repl" CMD="printenv"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -46,5 +46,5 @@ tasks:
       - nix log --no-warn-dirty ".#checks.{{.SYSTEM}}.ptcfmt"
   pi:
     desc: run pi agent with access to secrets
-    cmd: go-task _infisical-run  ENV=dev PATHS="/ai" CMD="pnpm run pi"
+    cmd: go-task _infisical-run  ENV=dev PATHS="/ai /repl" CMD="pnpm run pi"
 

--- a/apps/pi/extension/lisp-repl.ts
+++ b/apps/pi/extension/lisp-repl.ts
@@ -261,15 +261,15 @@ function registerFireworks(pi: ExtensionAPI): void {
 				contextWindow: 131072,
 				maxTokens: 65536,
 			},
-            {
-                id: "accounts/fireworks/models/gpt-oss-120b",
-				name: "GLM 5.2",
+			{
+				id: "accounts/fireworks/models/gpt-oss-120b",
+				name: "GPT-OSS 120B",
 				reasoning: false,
 				input: ["text"],
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				contextWindow: 131072,
 				maxTokens: 65536,
-            }
+			},
 		],
 	});
 }

--- a/apps/pi/extension/lisp-repl.ts
+++ b/apps/pi/extension/lisp-repl.ts
@@ -299,6 +299,22 @@ export default function (pi: ExtensionAPI) {
 			type: "grammar",
 			grammar: LISP_GRAMMAR,
 		};
+		// Set LISP_DEBUG=1 to confirm the grammar actually reaches the wire and
+		// see what model/reasoning fields pi built.
+		if (process.env.LISP_DEBUG) {
+			const p = payload as Record<string, unknown>;
+			console.error(
+				"[lisp-repl] request:",
+				JSON.stringify({
+					model: p.model,
+					stream: p.stream,
+					response_format: (p.response_format as { type?: string })?.type,
+					grammarLen: LISP_GRAMMAR.length,
+					reasoning_effort: p.reasoning_effort,
+					chat_template_kwargs: p.chat_template_kwargs,
+				}),
+			);
+		}
 		return payload;
 	});
 
@@ -384,6 +400,20 @@ export default function (pi: ExtensionAPI) {
 		// task — reset the step budget so each request gets a fresh loop.
 		if (msg.role === "user" && msg.customType === undefined) steps = 0;
 		if (event.message.role !== "assistant") return;
+		// LISP_DEBUG: show which channels the model used. If `text` is empty and
+		// the content is all `thinking`, the grammar constrained an empty answer
+		// while the real (unconstrained) output went to the reasoning channel.
+		if (process.env.LISP_DEBUG) {
+			console.error(
+				"[lisp-repl] reply parts:",
+				JSON.stringify(
+					event.message.content.map((c) => ({
+						type: c.type,
+						head: ("text" in c ? c.text : "").slice(0, 60),
+					})),
+				),
+			);
+		}
 		const code = event.message.content
 			.filter((c): c is { type: "text"; text: string } => c.type === "text")
 			.map((c) => c.text)

--- a/apps/pi/extension/lisp-repl.ts
+++ b/apps/pi/extension/lisp-repl.ts
@@ -246,13 +246,8 @@ function registerFireworks(pi: ExtensionAPI): void {
 			{
 				id: "accounts/fireworks/models/kimi-k3",
 				name: "Kimi K3",
-				// Thinking off at the provider level: declaring the model
-				// non-reasoning makes pi clamp its thinking level to off, so no
-				// `:off` CLI suffix is needed.
 				reasoning: false,
-				// Kimi K3 is multimodal — it accepts image_url content parts.
 				input: ["text", "image"],
-				// Pricing unknown for K3; left at zero rather than guessing.
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				contextWindow: 262144,
 				maxTokens: 131072,
@@ -262,11 +257,19 @@ function registerFireworks(pi: ExtensionAPI): void {
 				name: "GLM 5.2",
 				reasoning: false,
 				input: ["text"],
-				// Pricing/limits unknown; left at zero rather than guessing.
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				contextWindow: 131072,
 				maxTokens: 65536,
 			},
+            {
+                id: "accounts/fireworks/models/gpt-oss-120b",
+				name: "GLM 5.2",
+				reasoning: false,
+				input: ["text"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 131072,
+				maxTokens: 65536,
+            }
 		],
 	});
 }

--- a/apps/pi/extension/lisp-repl.ts
+++ b/apps/pi/extension/lisp-repl.ts
@@ -246,7 +246,19 @@ function registerFireworks(pi: ExtensionAPI): void {
 			{
 				id: "accounts/fireworks/models/kimi-k3",
 				name: "Kimi K3",
-				reasoning: false,
+				reasoning: true,
+				input: ["text", "image"],
+				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+				contextWindow: 262144,
+				maxTokens: 131072,
+			},
+			{
+				id: "accounts/fireworks/models/kimi-k2p7-code",
+				name: "Kimi K2.7 Code",
+				// reasoning MUST be true: with false, pi treats the model as
+				// non-reasoning and never sends a thinking-control param, so the
+				// `:off` level is ignored and the model reasons anyway.
+				reasoning: true,
 				input: ["text", "image"],
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				contextWindow: 262144,
@@ -255,7 +267,7 @@ function registerFireworks(pi: ExtensionAPI): void {
 			{
 				id: "accounts/fireworks/models/glm-5p2",
 				name: "GLM 5.2",
-				reasoning: false,
+				reasoning: true,
 				input: ["text"],
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				contextWindow: 131072,
@@ -264,7 +276,7 @@ function registerFireworks(pi: ExtensionAPI): void {
 			{
 				id: "accounts/fireworks/models/gpt-oss-120b",
 				name: "GPT-OSS 120B",
-				reasoning: false,
+				reasoning: true,
 				input: ["text"],
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				contextWindow: 131072,

--- a/apps/pi/extension/lisp-repl.ts
+++ b/apps/pi/extension/lisp-repl.ts
@@ -246,20 +246,13 @@ function registerFireworks(pi: ExtensionAPI): void {
 			{
 				id: "accounts/fireworks/models/kimi-k3",
 				name: "Kimi K3",
-				reasoning: true,
+				// Thinking off at the provider level: declaring the model
+				// non-reasoning makes pi clamp its thinking level to off, so no
+				// `:off` CLI suffix is needed.
+				reasoning: false,
+				// Kimi K3 is multimodal — it accepts image_url content parts.
 				input: ["text", "image"],
-				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-				contextWindow: 262144,
-				maxTokens: 131072,
-			},
-			{
-				id: "accounts/fireworks/models/kimi-k2p7-code",
-				name: "Kimi K2.7 Code",
-				// reasoning MUST be true: with false, pi treats the model as
-				// non-reasoning and never sends a thinking-control param, so the
-				// `:off` level is ignored and the model reasons anyway.
-				reasoning: true,
-				input: ["text", "image"],
+				// Pricing unknown for K3; left at zero rather than guessing.
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				contextWindow: 262144,
 				maxTokens: 131072,
@@ -267,17 +260,9 @@ function registerFireworks(pi: ExtensionAPI): void {
 			{
 				id: "accounts/fireworks/models/glm-5p2",
 				name: "GLM 5.2",
-				reasoning: true,
+				reasoning: false,
 				input: ["text"],
-				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-				contextWindow: 131072,
-				maxTokens: 65536,
-			},
-			{
-				id: "accounts/fireworks/models/gpt-oss-120b",
-				name: "GPT-OSS 120B",
-				reasoning: true,
-				input: ["text"],
+				// Pricing/limits unknown; left at zero rather than guessing.
 				cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
 				contextWindow: 131072,
 				maxTokens: 65536,
@@ -299,22 +284,6 @@ export default function (pi: ExtensionAPI) {
 			type: "grammar",
 			grammar: LISP_GRAMMAR,
 		};
-		// Set LISP_DEBUG=1 to confirm the grammar actually reaches the wire and
-		// see what model/reasoning fields pi built.
-		if (process.env.LISP_DEBUG) {
-			const p = payload as Record<string, unknown>;
-			console.error(
-				"[lisp-repl] request:",
-				JSON.stringify({
-					model: p.model,
-					stream: p.stream,
-					response_format: (p.response_format as { type?: string })?.type,
-					grammarLen: LISP_GRAMMAR.length,
-					reasoning_effort: p.reasoning_effort,
-					chat_template_kwargs: p.chat_template_kwargs,
-				}),
-			);
-		}
 		return payload;
 	});
 
@@ -400,20 +369,6 @@ export default function (pi: ExtensionAPI) {
 		// task — reset the step budget so each request gets a fresh loop.
 		if (msg.role === "user" && msg.customType === undefined) steps = 0;
 		if (event.message.role !== "assistant") return;
-		// LISP_DEBUG: show which channels the model used. If `text` is empty and
-		// the content is all `thinking`, the grammar constrained an empty answer
-		// while the real (unconstrained) output went to the reasoning channel.
-		if (process.env.LISP_DEBUG) {
-			console.error(
-				"[lisp-repl] reply parts:",
-				JSON.stringify(
-					event.message.content.map((c) => ({
-						type: c.type,
-						head: ("text" in c ? c.text : "").slice(0, 60),
-					})),
-				),
-			);
-		}
 		const code = event.message.content
 			.filter((c): c is { type: "text"; text: string } => c.type === "text")
 			.map((c) => c.text)

--- a/devdocs/README.md
+++ b/devdocs/README.md
@@ -1,0 +1,12 @@
+# Developer docs
+
+Design notes and setup guides for lisptc internals. Kept out of the source so the
+code comments stay short and point here for the detail.
+
+## Contents
+
+- [OAuth 2.1 for remote MCP servers](./oauth.md) — how `load-mcp` authenticates
+  OAuth servers (Linear): flow, callback strategies, token storage, cloud/ingress
+  config.
+- [Secret registry](./secrets.md) — the `REPL_*` secret store, taint-tracked
+  redaction, and how secrets reach MCP calls.

--- a/devdocs/oauth.md
+++ b/devdocs/oauth.md
@@ -1,0 +1,93 @@
+# OAuth 2.1 for remote MCP servers
+
+Remote MCP servers (e.g. Linear) authenticate with OAuth 2.1 — PKCE, dynamic
+client registration (DCR), and metadata discovery. The MCP SDK implements the
+whole protocol; lisptc only supplies **token persistence** and **redirect
+capture**. Code lives in `src/mcp-oauth.ts` (provider + storage + callback) and
+`src/mcp-broker.ts` (`connect` / `authorize`).
+
+## Marking a server as OAuth
+
+In `mcp.toolkit.json`, an HTTP server opts in with `oauth` and optional `scopes`:
+
+```json
+{ "name": "linear", "url": "https://mcp.linear.app/mcp", "oauth": true, "scopes": ["read", "write"] }
+```
+
+`scopes` become the space-separated `scope` on the authorization request. No
+`client_id`/secret is needed — DCR registers a client on the fly.
+
+## Flow from the REPL
+
+```lisp
+(await (load-mcp "linear"))
+;=> authorization required for "linear": open https://mcp.linear.app/authorize?…
+;   — after approving it will be captured automatically — then run (load-mcp "linear") again
+```
+
+1. **connect** attaches a `StoredOAuthProvider` to the transport. A stored token
+   connects directly (refreshed silently via the refresh token). With no usable
+   token the SDK runs discovery + DCR + PKCE, saves the PKCE verifier, captures
+   the authorization URL, and throws `UnauthorizedError`.
+2. The broker surfaces the URL (a `NeedsAuthError` whose message carries it) and,
+   in **local mode**, starts the loopback callback server.
+3. The user approves in a browser and is redirected to the callback with `?code`.
+4. The code is exchanged for tokens (`auth(provider, { authorizationCode })`),
+   which are saved. A subsequent `(load-mcp "linear")` connects; `linear/*` tools
+   bind.
+5. **Later sessions** reconnect silently from the stored refresh token.
+
+The code exchange is a **separate step** from the authorization request; they are
+bridged by the persisted PKCE verifier + client registration, so no live
+transport has to stay open. This is what lets the code arrive by loopback, manual
+paste, or a cloud ingress.
+
+## Callback strategies (`AuthCallback`)
+
+Swappable, chosen by `createAuthCallback()`:
+
+- **Loopback** (default, local): a transient HTTP server on `127.0.0.1:<port>`
+  (fixed, default `8909`) that auto-captures the redirect. Only reachable from a
+  browser on the same machine; shut down once the code arrives.
+- **External** (cloud): set `LISPTC_OAUTH_REDIRECT_URL` to a real callback URL
+  (your Kubernetes ingress). No local server; the ingress handler — or the user
+  via `(mcp-authorize "server" "<code>")` — delivers the code.
+
+### Manual fallback
+
+`(mcp-authorize "server" "<code>")` completes the exchange with a code obtained
+out-of-band. Used for headless/remote sessions and the external strategy.
+
+## Storage (`OAuthStore`)
+
+Persistence is behind the `OAuthStore` interface (async `load`/`save`/`clear`,
+keyed by server origin) so the backing store is swappable.
+
+- **`FileOAuthStore`** (default): one JSON file per server under
+  `$LISPTC_OAUTH_DIR` → `$XDG_CONFIG_HOME/lisptc/oauth` → `~/.config/lisptc/oauth`
+  (dir `0700`, files `0600`). E.g. `~/.config/lisptc/oauth/https___mcp.linear.app.json`,
+  holding `clientInformation`, `codeVerifier`, and (after approval) `tokens`.
+- **Database**: implement `OAuthStore` and change the single
+  `const oauthStore = new FileOAuthStore()` line in `src/mcp-broker.ts`.
+
+Reset a server's OAuth by deleting its file.
+
+## Configuration
+
+| Env var | Purpose | Default |
+| --- | --- | --- |
+| `LISPTC_OAUTH_REDIRECT_URL` | Public callback URL → external (cloud) mode | unset → loopback |
+| `LISPTC_OAUTH_CALLBACK_PORT` | Loopback port (must match the registered redirect) | `8909` |
+| `LISPTC_OAUTH_DIR` | Token store directory | XDG config dir |
+
+## Notes & gotchas
+
+- **Redirect URI must stay stable.** A DCR registration pins the redirect URI it
+  was created with. If it changes (host/port), the authorization request is
+  rejected with *"invalid redirect URI"*. `connect` self-heals by dropping a
+  stored registration whose `redirect_uris` don't include the current one, so the
+  SDK re-registers.
+- **Callback page** is served as `text/html; charset=utf-8` (otherwise the em-dash
+  renders as mojibake).
+- **Loopback is same-machine only.** For SSH/remote, either port-forward the
+  callback port or use the external strategy + `mcp-authorize`.

--- a/devdocs/oauth.md
+++ b/devdocs/oauth.md
@@ -73,13 +73,27 @@ only where it binds and the URL it advertises differ (`createAuthCallback(port)`
   `host:port` — the ingress bridges them.
 
 On the needs-auth path the server auto-captures the code and exchanges it in the
-background; then a subsequent `(load-mcp "server")` connects. It binds on-demand
-(during the auth window) and shuts down once the code arrives.
+background; then a subsequent `(load-mcp "server")` connects. A single long-lived
+server (bound on first need) multiplexes every flow, routing each callback to the
+authorization that owns its OAuth `state`. This is why several outstanding login
+links — e.g. one per concurrent background `load-mcp` — each complete
+independently: each flow's exchange runs against the **originating provider** (its
+in-memory PKCE verifier), so a later login for the same server overwriting the
+stored verifier doesn't break an earlier link.
+
+The browser page reflects the **real** outcome: the token exchange runs *before*
+the page is rendered, so a code that fails to exchange (or an `?error=` redirect,
+or a callback for an unknown/expired `state`) shows an error page rather than a
+misleading "Authorization complete".
 
 ### Manual fallback
 
 `(mcp-authorize "server" "<code>")` completes the exchange with a code obtained
-out-of-band — for headless sessions or if the callback port is busy.
+out-of-band — for headless sessions or if the callback port is busy. It accepts
+either the bare code or the whole pasted callback link
+(`…/callback?code=…&state=…`), pulling the `code` out of the URL. Unlike the
+auto-capture path it rebuilds the provider from the store, so it uses the
+**latest** stored PKCE verifier — paste the code from the most recent login link.
 
 ### Login / logout
 

--- a/devdocs/oauth.md
+++ b/devdocs/oauth.md
@@ -72,6 +72,12 @@ background; then a subsequent `(load-mcp "server")` connects. It binds on-demand
 `(mcp-authorize "server" "<code>")` completes the exchange with a code obtained
 out-of-band — for headless sessions or if the callback port is busy.
 
+### Logout
+
+`(logout "server")` unloads the server (if loaded) and deletes its saved session
+via `OAuthStore.clear`, so the next `(load-mcp "server")` re-authorizes from
+scratch — e.g. after widening `scopes`.
+
 ## Storage (`OAuthStore`)
 
 Persistence is behind the `OAuthStore` interface (async `load`/`save`/`clear`,

--- a/devdocs/oauth.md
+++ b/devdocs/oauth.md
@@ -14,8 +14,13 @@ In `mcp.toolkit.json`, an HTTP server opts in with `oauth` and optional `scopes`
 { "name": "linear", "url": "https://mcp.linear.app/mcp", "oauth": true, "scopes": ["read", "write"] }
 ```
 
-`scopes` become the space-separated `scope` on the authorization request. No
-`client_id`/secret is needed — DCR registers a client on the fly.
+`scopes` become the space-separated `scope` on the authorization request. The
+broker drives authorization itself (`auth(provider, { scope })`) so exactly these
+scopes are requested — otherwise the SDK would request the server's entire
+advertised `scopes_supported`, which some servers (PostHog) reject as
+`invalid_scope`. Pick scopes the server actually grants. No `client_id`/secret is
+needed — DCR registers a client on the fly, and the provider sends an OAuth
+`state` (required by some servers, e.g. PostHog).
 
 ## Flow from the REPL
 

--- a/devdocs/oauth.md
+++ b/devdocs/oauth.md
@@ -72,11 +72,14 @@ background; then a subsequent `(load-mcp "server")` connects. It binds on-demand
 `(mcp-authorize "server" "<code>")` completes the exchange with a code obtained
 out-of-band — for headless sessions or if the callback port is busy.
 
-### Logout
+### Login / logout
 
-`(logout "server")` unloads the server (if loaded) and deletes its saved session
-via `OAuthStore.clear`, so the next `(load-mcp "server")` re-authorizes from
-scratch — e.g. after widening `scopes`.
+`(login "server")` begins authorization and returns the login URL to open (or
+`:logged-in` if already authenticated); after approving, `(load-mcp "server")`
+connects. `(logout "server")` unloads the server (if loaded) and deletes its
+saved session via `OAuthStore.clear`, so the next login re-authorizes from
+scratch — e.g. after widening `scopes`. Both share `connect`'s auth kickoff
+(`ensureAuthorized`).
 
 ## Storage (`OAuthStore`)
 

--- a/devdocs/oauth.md
+++ b/devdocs/oauth.md
@@ -42,21 +42,30 @@ bridged by the persisted PKCE verifier + client registration, so no live
 transport has to stay open. This is what lets the code arrive by loopback, manual
 paste, or a cloud ingress.
 
-## Callback strategies (`AuthCallback`)
+## Callback server (`CallbackServer`)
 
-Swappable, chosen by `createAuthCallback()`:
+The **same** application serves the callback and saves the tokens in both modes;
+only where it binds and the URL it advertises differ (`createAuthCallback(port)`):
 
-- **Loopback** (default, local): a transient HTTP server on `127.0.0.1:<port>`
-  (fixed, default `8909`) that auto-captures the redirect. Only reachable from a
-  browser on the same machine; shut down once the code arrives.
-- **External** (cloud): set `LISPTC_OAUTH_REDIRECT_URL` to a real callback URL
-  (your Kubernetes ingress). No local server; the ingress handler — or the user
-  via `(mcp-authorize "server" "<code>")` — delivers the code.
+- **Local** (default): binds `127.0.0.1:<port>` (default `8909`) and advertises
+  `http://127.0.0.1:<port>/callback`. Reachable only from a browser on the same
+  machine.
+- **Ingress** (cloud): set `LISPTC_OAUTH_REDIRECT_URL` to your public callback
+  (e.g. `https://mcp.example.com/oauth/callback`). The server then binds
+  `0.0.0.0:<port>` (reachable via the ingress) and advertises the public URL.
+  The ingress routes `https://…/oauth/callback` to the pod's `0.0.0.0:<port>`
+  at the same path; the server captures the code and exchanges it, exactly as
+  local mode does. The advertised redirect URL may differ from the bind
+  `host:port` — the ingress bridges them.
+
+On the needs-auth path the server auto-captures the code and exchanges it in the
+background; then a subsequent `(load-mcp "server")` connects. It binds on-demand
+(during the auth window) and shuts down once the code arrives.
 
 ### Manual fallback
 
 `(mcp-authorize "server" "<code>")` completes the exchange with a code obtained
-out-of-band. Used for headless/remote sessions and the external strategy.
+out-of-band — for headless sessions or if the callback port is busy.
 
 ## Storage (`OAuthStore`)
 

--- a/devdocs/oauth.md
+++ b/devdocs/oauth.md
@@ -4,7 +4,8 @@ Remote MCP servers (e.g. Linear) authenticate with OAuth 2.1 — PKCE, dynamic
 client registration (DCR), and metadata discovery. The MCP SDK implements the
 whole protocol; lisptc only supplies **token persistence** and **redirect
 capture**. Code lives in `src/mcp-oauth.ts` (provider + storage + callback) and
-`src/mcp-broker.ts` (`connect` / `authorize`).
+`src/mcp-broker.ts` (`ensureAuthorized` + the `connect` / `login` / `authorize` /
+`logout` ops), surfaced as the `login` / `logout` / `mcp-authorize` built-ins.
 
 ## Marking a server as OAuth
 
@@ -18,29 +19,37 @@ In `mcp.toolkit.json`, an HTTP server opts in with `oauth` and optional `scopes`
 broker drives authorization itself (`auth(provider, { scope })`) so exactly these
 scopes are requested — otherwise the SDK would request the server's entire
 advertised `scopes_supported`, which some servers (PostHog) reject as
-`invalid_scope`. Pick scopes the server actually grants. No `client_id`/secret is
-needed — DCR registers a client on the fly, and the provider sends an OAuth
-`state` (required by some servers, e.g. PostHog).
+`invalid_scope`. Pick scopes the **authorization server** actually grants (which
+may be a subset of what the resource advertises). No `client_id`/secret is needed
+— DCR registers a client on the fly, and the provider sends an OAuth `state`
+(required by some servers, e.g. PostHog).
+
+Examples in `mcp.toolkit.json`: `linear` (`read`, `write`) and `posthog` (a
+curated subset including `openid`, `insight:read/write`, …, `user:read`).
 
 ## Flow from the REPL
 
 ```lisp
-(await (load-mcp "linear"))
-;=> authorization required for "linear": open https://mcp.linear.app/authorize?…
-;   — after approving it will be captured automatically — then run (load-mcp "linear") again
+(login "linear")               ; or: (await (load-mcp "linear"))
+;=> "https://linear.app/oauth/authorize?…"   (or :logged-in if already authed)
+;;  approve in the browser → the code is captured automatically
+(await (load-mcp "linear"))    ;=> connects; linear/* tools bind
 ```
 
-1. **connect** attaches a `StoredOAuthProvider` to the transport. A stored token
-   connects directly (refreshed silently via the refresh token). With no usable
-   token the SDK runs discovery + DCR + PKCE, saves the PKCE verifier, captures
-   the authorization URL, and throws `UnauthorizedError`.
-2. The broker surfaces the URL (a `NeedsAuthError` whose message carries it) and,
-   in **local mode**, starts the loopback callback server.
-3. The user approves in a browser and is redirected to the callback with `?code`.
+1. **`ensureAuthorized`** (used by both `connect` and `login`) creates a
+   `StoredOAuthProvider`. A stored token means connect proceeds directly
+   (refreshed silently via the refresh token). With no token it runs discovery +
+   DCR + PKCE (`auth(provider, { scope })`), saves the PKCE verifier, and captures
+   the authorization URL.
+2. The URL is surfaced — as `login`'s return value, or as the `NeedsAuthError`
+   message on the `load-mcp` job — and, on the needs-auth path, the callback
+   server is started.
+3. The user approves and is redirected to the callback with `?code`.
 4. The code is exchanged for tokens (`auth(provider, { authorizationCode })`),
-   which are saved. A subsequent `(load-mcp "linear")` connects; `linear/*` tools
-   bind.
-5. **Later sessions** reconnect silently from the stored refresh token.
+   saved to the store. A subsequent `(load-mcp "linear")` connects.
+5. **Later sessions** reconnect silently from the stored refresh token; if a
+   stored token is rejected (`UnauthorizedError`), `connect` drops it and
+   re-authorizes.
 
 The code exchange is a **separate step** from the authorization request; they are
 bridged by the persisted PKCE verifier + client registration, so no live
@@ -107,9 +116,14 @@ Reset a server's OAuth by deleting its file.
 
 - **Redirect URI must stay stable.** A DCR registration pins the redirect URI it
   was created with. If it changes (host/port), the authorization request is
-  rejected with *"invalid redirect URI"*. `connect` self-heals by dropping a
-  stored registration whose `redirect_uris` don't include the current one, so the
-  SDK re-registers.
+  rejected with *"invalid redirect URI"*. `ensureAuthorized` self-heals by
+  dropping a stored registration whose `redirect_uris` don't include the current
+  one, so the SDK re-registers.
+- **Insufficient scope (403).** If a server needs a scope you didn't request, a
+  tool call returns `403 insufficient_scope` naming it (e.g. PostHog needs
+  `user:read`). The SDK can't re-consent mid-connect — add the scope to the
+  server's `scopes` in `mcp.toolkit.json`, then `(logout "server")` and
+  `(login "server")` again.
 - **Callback page** is served as `text/html; charset=utf-8` (otherwise the em-dash
   renders as mojibake).
 - **Loopback is same-machine only.** For SSH/remote, either port-forward the

--- a/devdocs/secrets.md
+++ b/devdocs/secrets.md
@@ -1,0 +1,62 @@
+# Secret registry
+
+A host-supplied key→value store of secrets. Keys (and descriptions) are listable
+by the LLM; values are usable as ordinary strings but never printed. Code lives
+in `src/lisp.ts` (registry + `Secret` + string primitives) and `src/repl.ts`
+(host injection).
+
+## Lisp API
+
+```lisp
+(secrets)                       ; => (("REPL_LINEAR_API_KEY" . "Linear API key") …)
+(secret "REPL_LINEAR_API_KEY")  ; => #<secret:REPL_LINEAR_API_KEY>  (redacted)
+```
+
+`(secrets)` returns an alist of `(key . description)`. `(secret key)` returns the
+value as a **tainted string** — every text function works on it, but it prints
+redacted and errors if the key is unknown.
+
+## The `REPL_` prefix
+
+Only keys starting with `REPL_` become secrets, and the prefix is kept (read a
+secret back by its full name). This applies to every source: env vars, `.env`
+files, and host-supplied records.
+
+## Sources
+
+| Source | How | Description? |
+| --- | --- | --- |
+| Env vars | `REPL_*` seeded at `Interp` construction | none |
+| `.env` file | `Interp.loadSecretsFromFile(path)` / CLI auto-load | none |
+| Host (programmatic) | `setSecrets({ KEY: value \| { value, description } })` | optional |
+
+`.env` auto-loading is **CLI-only** (`$LISPTC_SECRETS_FILE` or `./.env`); the
+embedded `AgentRepl` (pi) does **not** auto-load — a host injects secrets
+explicitly via `setSecrets` / `loadSecretsFromFile`, re-applied on `reset()`.
+
+## Redaction via taint tracking
+
+A secret is a `Secret` (value + source keys). `str()` renders it redacted as
+`#<secret:KEY>`, covering every print path (return value, `princ`, errors, nested
+lists) from one place. The value is revealed only by `lispToJson` when serialized
+into an outgoing MCP call (tool args, `:headers`, `:env`).
+
+Taint **propagates**: the JS string primitives (`concat`, `char`,
+`string-upcase`/`downcase`) accept a `Secret`, and a result derived from one is
+itself a `Secret`. Because the Lisp string library is built on those primitives,
+transforms (`substring`, etc.) stay redacted for free — so an agent cannot
+upcase/slice its way around the redaction. `length`/`stringp`/`eql` treat a
+secret as its string, so predicates still work.
+
+Combining secrets unions the taint: `(concat (secret "REPL_A") (secret "REPL_B"))`
+→ `#<secret:REPL_A+REPL_B>`.
+
+## Limits (by design)
+
+- Taint follows data **inside the interpreter only** — it does not cross the MCP
+  boundary. A tool that echoes a secret returns a fresh, untainted string. So
+  redaction stops *accidental* display, not *deliberate* exfiltration by an agent
+  with tool access.
+- `eql` compares tainted strings by value — a weak equality oracle.
+- Value use in an MCP call is the intended path; controlling *which* servers/tools
+  a secret may reach is a separate concern from redaction.

--- a/examples/sample.ptc
+++ b/examples/sample.ptc
@@ -163,3 +163,4 @@
 (playwright/browser_navigate :url "yourscrib.ai")
 
 (unload-mcp "playwright")
+

--- a/examples/sample.ptc
+++ b/examples/sample.ptc
@@ -164,3 +164,5 @@
 
 (unload-mcp "playwright")
 
+(await (load-mcp :name "linear" :url "https://mcp.linear.app/mcp" :headers (list (cons "Authorization" (concat "Bearer " (secret "LINEAR_API_KEY"))))))
+(secrets)

--- a/examples/sample.ptc
+++ b/examples/sample.ptc
@@ -170,3 +170,10 @@
 (concat (secret "REPL_LINEAR_API_KEY") "--test")
 
 (length (secret "REPL_LINEAR_API_KEY"))
+
+(defmacro swap (a b) `(let ((tmp ,a)) (setq ,a ,b) (setq ,b tmp)))
+(setq p 1)
+(setq q 2)
+
+(swap p q)
+(list q p)

--- a/examples/sample.ptc
+++ b/examples/sample.ptc
@@ -166,3 +166,7 @@
 
 (await (load-mcp :name "linear" :url "https://mcp.linear.app/mcp" :headers (list (cons "Authorization" (concat "Bearer " (secret "LINEAR_API_KEY"))))))
 (secrets)
+
+(concat (secret "REPL_LINEAR_API_KEY") "--test")
+
+(length (secret "REPL_LINEAR_API_KEY"))

--- a/knip.json
+++ b/knip.json
@@ -2,6 +2,10 @@
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "ignoreBinaries": ["pi"],
   "workspaces": {
+    ".": {
+      "entry": ["scripts/*.ts"],
+      "project": ["scripts/**/*.ts"]
+    },
     "packages/interpreter": {
       "entry": ["test/**/*.test.ts"],
       "project": ["src/**/*.ts"]

--- a/knip.json
+++ b/knip.json
@@ -6,6 +6,10 @@
       "entry": ["scripts/*.ts"],
       "project": ["scripts/**/*.ts"]
     },
+    "packages/env": {
+      "entry": ["src/*.ts"],
+      "project": ["src/**/*.ts"]
+    },
     "packages/interpreter": {
       "entry": ["test/**/*.test.ts"],
       "project": ["src/**/*.ts"]

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "biome ci",
     "format": "biome check --write",
     "knip": "knip",
-    "pi": "pi --provider fireworks --model accounts/fireworks/models/gpt-oss-120b",
+    "pi": "pi --provider fireworks --model accounts/fireworks/models/kimi-k2p7-code:off",
     "prepare": "husky"
   },
   "pi": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "biome ci",
     "format": "biome check --write",
     "knip": "knip",
-    "pi": "pi --provider fireworks --model accounts/fireworks/models/kimi-k3:off",
+    "pi": "pi --provider fireworks --model accounts/fireworks/models/gpt-oss-120b",
     "prepare": "husky"
   },
   "pi": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "biome ci",
     "format": "biome check --write",
     "knip": "knip",
-    "pi": "pi --provider fireworks --model accounts/fireworks/models/kimi-k2p7-code:off",
+    "pi": "pi --provider fireworks --model accounts/fireworks/models/kimi-k3:low",
     "prepare": "husky"
   },
   "pi": {

--- a/package.json
+++ b/package.json
@@ -32,8 +32,11 @@
     "@commitlint/cli": "^21.2.1",
     "@commitlint/config-conventional": "^21.2.0",
     "@commitlint/types": "^21.2.0",
+    "@infisical/sdk": "^5.0.2",
+    "cmd-ts": "^0.15.0",
     "husky": "^9.1.7",
     "knip": "^6.27.0",
+    "tsx": "^4.23.1",
     "turbo": "^2.5.0",
     "typescript": "^5.9.3"
   }

--- a/packages/env/package.json
+++ b/packages/env/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@repo/env",
+  "version": "0.0.0",
+  "type": "module",
+  "private": true,
+  "exports": {
+    ".": "./src/index.ts",
+    "./ai.ts": "./src/ai.ts",
+    "./repl.ts": "./src/repl.ts",
+    "./oauth.ts": "./src/oauth.ts",
+    "./package.json": "./package.json"
+  },
+  "engines": {
+    "node": ">=22.6.0"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@t3-oss/env-core": "^0.13.11",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.9.3"
+  }
+}

--- a/packages/env/src/ai.ts
+++ b/packages/env/src/ai.ts
@@ -1,0 +1,11 @@
+import { createEnv } from "@t3-oss/env-core";
+import { z } from "zod";
+
+// AI provider credentials (Fireworks).
+export const aiEnv = createEnv({
+	server: {
+		FIREWORKS_API_KEY: z.string().optional(),
+	},
+	runtimeEnv: process.env,
+	emptyStringAsUndefined: true,
+});

--- a/packages/env/src/index.ts
+++ b/packages/env/src/index.ts
@@ -1,0 +1,5 @@
+// Per-domain, validated environment (t3-env). Import a specific domain to keep
+// validation scoped, e.g. `import { oauthEnv } from "@repo/env/oauth.ts"`.
+export { aiEnv } from "./ai.ts";
+export { oauthEnv } from "./oauth.ts";
+export { replEnv } from "./repl.ts";

--- a/packages/env/src/oauth.ts
+++ b/packages/env/src/oauth.ts
@@ -1,0 +1,19 @@
+import { createEnv } from "@t3-oss/env-core";
+import { z } from "zod";
+
+// OAuth / token-store configuration for remote MCP servers. All optional — the
+// consumers fall back to loopback + XDG defaults. See devdocs/oauth.md.
+export const oauthEnv = createEnv({
+	server: {
+		// Public callback URL (e.g. a Kubernetes ingress). Set => cloud mode.
+		LISPTC_OAUTH_REDIRECT_URL: z.string().optional(),
+		// Loopback callback port (must match the registered redirect).
+		LISPTC_OAUTH_CALLBACK_PORT: z.coerce.number().int().positive().optional(),
+		// Token store directory override.
+		LISPTC_OAUTH_DIR: z.string().optional(),
+		// XDG base dir used to derive the default token store location.
+		XDG_CONFIG_HOME: z.string().optional(),
+	},
+	runtimeEnv: process.env,
+	emptyStringAsUndefined: true,
+});

--- a/packages/env/src/repl.ts
+++ b/packages/env/src/repl.ts
@@ -1,0 +1,15 @@
+import { createEnv } from "@t3-oss/env-core";
+import { z } from "zod";
+
+// REPL configuration. Note: the per-key `REPL_*` secret registry is a dynamic
+// prefix scan of process.env (arbitrary names), so it stays outside this schema.
+export const replEnv = createEnv({
+	server: {
+		// `.env` file the standalone CLI seeds secrets from.
+		LISPTC_SECRETS_FILE: z.string().optional(),
+		// Truthy => extra debug logging in the pi extension.
+		LISP_DEBUG: z.string().optional(),
+	},
+	runtimeEnv: process.env,
+	emptyStringAsUndefined: true,
+});

--- a/packages/env/tsconfig.json
+++ b/packages/env/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src"]
+}

--- a/packages/interpreter/mcp.toolkit.json
+++ b/packages/interpreter/mcp.toolkit.json
@@ -17,5 +17,12 @@
     "description": "Read, write, and list files under the current working directory.",
     "command": "npx",
     "args": ["-y", "@modelcontextprotocol/server-filesystem", "."]
+  },
+  {
+    "name": "linear",
+    "description": "Linear issue tracker over OAuth: search/list/create issues, projects, comments. First (load-mcp \"linear\") returns an authorization link; approve it, run (mcp-authorize \"linear\" \"<code>\"), then load again.",
+    "url": "https://mcp.linear.app/mcp",
+    "oauth": true,
+    "scopes": ["read", "write"]
   }
 ]

--- a/packages/interpreter/mcp.toolkit.json
+++ b/packages/interpreter/mcp.toolkit.json
@@ -24,5 +24,35 @@
     "url": "https://mcp.linear.app/mcp",
     "oauth": true,
     "scopes": ["read", "write"]
+  },
+  {
+    "name": "posthog",
+    "description": "PostHog product analytics over OAuth: query insights, dashboards, feature flags, experiments, error tracking, events, and SQL. First (load-mcp \"posthog\") returns an authorization link; approve it, run (mcp-authorize \"posthog\" \"<code>\"), then load again. Edit `scopes` to grant more.",
+    "url": "https://mcp.posthog.com/mcp",
+    "oauth": true,
+    "scopes": [
+      "openid",
+      "profile",
+      "email",
+      "insight:read",
+      "insight:write",
+      "dashboard:read",
+      "dashboard:write",
+      "feature_flag:read",
+      "feature_flag:write",
+      "experiment:read",
+      "experiment:write",
+      "error_tracking:read",
+      "error_tracking:write",
+      "query:read",
+      "event_definition:read",
+      "property_definition:read",
+      "person:read",
+      "cohort:read",
+      "survey:read",
+      "session_recording:read",
+      "organization:read",
+      "project:read"
+    ]
   }
 ]

--- a/packages/interpreter/mcp.toolkit.json
+++ b/packages/interpreter/mcp.toolkit.json
@@ -52,7 +52,8 @@
       "survey:read",
       "session_recording:read",
       "organization:read",
-      "project:read"
+      "project:read",
+      "user:read"
     ]
   }
 ]

--- a/packages/interpreter/package.json
+++ b/packages/interpreter/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.12.0",
+    "@repo/env": "workspace:*",
     "dotenv": "^17.4.2"
   },
   "devDependencies": {

--- a/packages/interpreter/package.json
+++ b/packages/interpreter/package.json
@@ -25,7 +25,8 @@
     "repl": "node --no-warnings --experimental-transform-types src/cli.ts"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.0"
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "dotenv": "^17.4.2"
   },
   "devDependencies": {
     "@types/node": "^22.0.0",

--- a/packages/interpreter/src/cli.ts
+++ b/packages/interpreter/src/cli.ts
@@ -16,22 +16,7 @@ import {
 	setWriter,
 	str,
 } from "./lisp.ts";
-import type { Repl } from "./repl.ts";
-
-// Seed the secret registry from a `.env` file for the standalone REPL: the path
-// in $LISPTC_SECRETS_FILE, or `.env` in the working directory if it exists.
-// (Named without the `REPL_` prefix so it isn't itself seeded as a secret;
-// `REPL_*` env vars are seeded by the Interp constructor regardless.)
-function loadSecretsFile(interp: Interp): void {
-	const explicit = process.env.LISPTC_SECRETS_FILE;
-	const path = explicit ?? ".env";
-	try {
-		interp.loadSecretsFromFile(path);
-	} catch {
-		// A missing default `.env` is fine; only warn if one was named explicitly.
-		if (explicit) write(`warning: could not read secrets file ${explicit}\n`);
-	}
-}
+import { type Repl, seedSecretsFromEnvFile } from "./repl.ts";
 
 // Read a line as a string (displaying the given prompt), or null on EOF.
 // Wired to a readline interface by main().
@@ -59,7 +44,7 @@ class InteractiveRepl implements Repl {
 	private freshInterp(): Interp {
 		const interp = new Interp();
 		run(interp, prelude);
-		loadSecretsFile(interp);
+		seedSecretsFromEnvFile(interp);
 		return interp;
 	}
 

--- a/packages/interpreter/src/cli.ts
+++ b/packages/interpreter/src/cli.ts
@@ -86,9 +86,10 @@ class InteractiveRepl implements Repl {
 					return;
 				}
 				const result = this.currentInterp.eval(exp, null);
-				write(`${str(result)}\n`);
+				write(this.currentInterp.redactSecrets(`${str(result)}\n`));
 			} catch (ex) {
-				if (ex instanceof EvalException) write(`${ex}\n`);
+				if (ex instanceof EvalException)
+					write(this.currentInterp.redactSecrets(`${ex}\n`));
 				else throw ex;
 			}
 		}
@@ -189,10 +190,11 @@ async function main(): Promise<void> {
 		return line;
 	};
 
-	setWriter(write);
-	setExit(process.exit);
-
 	const repl = new InteractiveRepl();
+	// Redact secret values from side-effect output (prin1/princ) too, using the
+	// current interp's registry.
+	setWriter((s) => write(repl.interp.redactSecrets(s)));
+	setExit(process.exit);
 	let started = false;
 	let fs: typeof import("node:fs") | undefined;
 	let argv = process.argv as string[];

--- a/packages/interpreter/src/cli.ts
+++ b/packages/interpreter/src/cli.ts
@@ -18,6 +18,21 @@ import {
 } from "./lisp.ts";
 import type { Repl } from "./repl.ts";
 
+// Seed the secret registry from a `.env` file for the standalone REPL: the path
+// in $LISPTC_SECRETS_FILE, or `.env` in the working directory if it exists.
+// (Named without the `REPL_` prefix so it isn't itself seeded as a secret;
+// `REPL_*` env vars are seeded by the Interp constructor regardless.)
+function loadSecretsFile(interp: Interp): void {
+	const explicit = process.env.LISPTC_SECRETS_FILE;
+	const path = explicit ?? ".env";
+	try {
+		interp.loadSecretsFromFile(path);
+	} catch {
+		// A missing default `.env` is fine; only warn if one was named explicitly.
+		if (explicit) write(`warning: could not read secrets file ${explicit}\n`);
+	}
+}
+
 // Read a line as a string (displaying the given prompt), or null on EOF.
 // Wired to a readline interface by main().
 let readLine: (prompt: string) => Promise<string | null>;
@@ -44,6 +59,7 @@ class InteractiveRepl implements Repl {
 	private freshInterp(): Interp {
 		const interp = new Interp();
 		run(interp, prelude);
+		loadSecretsFile(interp);
 		return interp;
 	}
 

--- a/packages/interpreter/src/cli.ts
+++ b/packages/interpreter/src/cli.ts
@@ -86,10 +86,9 @@ class InteractiveRepl implements Repl {
 					return;
 				}
 				const result = this.currentInterp.eval(exp, null);
-				write(this.currentInterp.redactSecrets(`${str(result)}\n`));
+				write(`${str(result)}\n`);
 			} catch (ex) {
-				if (ex instanceof EvalException)
-					write(this.currentInterp.redactSecrets(`${ex}\n`));
+				if (ex instanceof EvalException) write(`${ex}\n`);
 				else throw ex;
 			}
 		}
@@ -190,11 +189,10 @@ async function main(): Promise<void> {
 		return line;
 	};
 
-	const repl = new InteractiveRepl();
-	// Redact secret values from side-effect output (prin1/princ) too, using the
-	// current interp's registry.
-	setWriter((s) => write(repl.interp.redactSecrets(s)));
+	setWriter(write);
 	setExit(process.exit);
+
+	const repl = new InteractiveRepl();
 	let started = false;
 	let fs: typeof import("node:fs") | undefined;
 	let argv = process.argv as string[];

--- a/packages/interpreter/src/lisp.ts
+++ b/packages/interpreter/src/lisp.ts
@@ -544,6 +544,10 @@ function propagateTaint(
 	return keys.length > 0 ? new Secret(value, keys) : value;
 }
 
+// How a host supplies a secret: either just its value, or its value plus a
+// human-readable description shown by `(secrets)` so the LLM knows what it is.
+export type SecretSpec = string | { value: string; description?: string };
+
 // Required prefix for every registry key. Only `REPL_*` names become secrets,
 // and the prefix is kept, so `REPL_LINEAR_API_KEY` is read back as the secret
 // keyed `REPL_LINEAR_API_KEY` (both from env vars and host-supplied records).
@@ -553,11 +557,15 @@ export class Interp {
 	// Table of the global values of symbols
 	private readonly globals: Map<Sym, unknown> = new Map();
 
-	// Host-supplied secret registry: key -> real value. Keys are listable by the
-	// LLM (`(secrets)`); values are only obtainable as opaque `Secret` objects
-	// via `(secret "key")` and are never printed. Seeded from `REPL_*` env vars
-	// at construction; `setSecrets` (from the host) overrides those.
-	private readonly secrets: Map<string, string> = new Map();
+	// Host-supplied secret registry: key -> { value, description }. Keys and
+	// descriptions are listable by the LLM (`(secrets)`); values are only
+	// obtainable as tainted `Secret` strings via `(secret "key")` and are never
+	// printed. Seeded from `REPL_*` env vars at construction (no description);
+	// `setSecrets` (from the host) overrides those and can attach descriptions.
+	private readonly secrets: Map<
+		string,
+		{ value: string; description: string }
+	> = new Map();
 
 	// Directories to resolve relative `import` paths against — one entry per
 	// file currently being loaded (the innermost import wins). Empty at the REPL,
@@ -1020,13 +1028,15 @@ export class Interp {
 			"secrets",
 			0,
 			"(secrets)",
-			"Return the list of available secret keys. Values are hidden — read a secret with `(secret key)`.",
+			"Return an alist of (key . description) for every available secret. Values are hidden — read one with `(secret key)`.",
 			z.tuple([]),
 			() => {
 				let list: List = null;
-				const keys = this.secretKeys();
-				for (let i = keys.length - 1; i >= 0; i--)
-					list = new Cell(keys[i], list);
+				const entries = [...this.secrets.entries()];
+				for (let i = entries.length - 1; i >= 0; i--) {
+					const [key, { description }] = entries[i];
+					list = new Cell(new Cell(key, description), list);
+				}
 				return list;
 			},
 		);
@@ -1037,10 +1047,10 @@ export class Interp {
 			"Return the secret stored under `key` as a tainted string: every text function works on it and the taint follows into the result, but it always prints redacted (as #<secret:key>) and is only revealed when passed into a call such as an MCP tool or `:headers`. Errors if `key` is unknown.",
 			z.tuple([zString]),
 			([key]) => {
-				const value = this.secrets.get(key);
-				if (value === undefined)
+				const entry = this.secrets.get(key);
+				if (entry === undefined)
 					throw new EvalException("unknown secret", key, false);
-				return new Secret(value, [key]);
+				return new Secret(entry.value, [key]);
 			},
 		);
 
@@ -1088,9 +1098,15 @@ export class Interp {
 	// (e.g. env-seeded) entries with the same key. Only keys starting with the
 	// `REPL_` prefix are accepted; the prefix is kept as part of the key, so a
 	// secret is read back with its full name, e.g. `(secret "REPL_LINEAR_API_KEY")`.
-	setSecrets(record: Record<string, string>): void {
-		for (const [key, value] of Object.entries(record))
-			if (key.startsWith(SECRET_ENV_PREFIX)) this.secrets.set(key, value);
+	// Each spec is either a bare value or `{ value, description }`.
+	setSecrets(record: Record<string, SecretSpec>): void {
+		for (const [key, spec] of Object.entries(record)) {
+			if (!key.startsWith(SECRET_ENV_PREFIX)) continue;
+			const value = typeof spec === "string" ? spec : spec.value;
+			const description =
+				typeof spec === "string" ? "" : (spec.description ?? "");
+			this.secrets.set(key, { value, description });
+		}
 	}
 
 	// The registry keys the LLM is allowed to see (values stay hidden).
@@ -1113,7 +1129,7 @@ export class Interp {
 	private seedSecretsFromEnv(): void {
 		for (const [name, value] of Object.entries(process.env)) {
 			if (value !== undefined && name.startsWith(SECRET_ENV_PREFIX))
-				this.secrets.set(name, value);
+				this.secrets.set(name, { value, description: "" });
 		}
 	}
 

--- a/packages/interpreter/src/lisp.ts
+++ b/packages/interpreter/src/lisp.ts
@@ -213,9 +213,8 @@ const zString = z.custom<string>(
 	(x) => typeof x === "string",
 	"string expected",
 );
-// Accepts a plain string or a tainted secret (see the `Secret` class). Used by
-// the string primitives so secrets flow through them; read the underlying text
-// with `secretValue` and re-taint the result with `propagateTaint`.
+// A plain string or a tainted secret; used by the string primitives so secrets
+// flow through (read with `secretValue`, re-taint with `propagateTaint`).
 const zStringLike = z.custom<string | Secret>(
 	(x) => typeof x === "string" || x instanceof Secret,
 	"string expected",
@@ -503,13 +502,10 @@ function listToStrings(list: List): string[] {
 	return out;
 }
 
-// A tainted string: the value of a secret, or anything derived from one. It
-// behaves like a string everywhere in the interpreter (the string primitives
-// accept it and propagate the taint into their results), but `str` renders it
-// redacted as `#<secret:KEY>` — so a secret and everything computed from it is
-// never printed, while the real value is still usable (revealed by `lispToJson`
-// when passed into an outgoing MCP call). `keys` records which registry secrets
-// it descends from (more than one after e.g. concatenating two secrets).
+// A tainted string: a secret's value, or anything derived from one. Behaves like
+// a string but `str` renders it redacted as `#<secret:KEY>`; the value is
+// revealed only by `lispToJson` into an MCP call. `keys` are the source secrets
+// (>1 after combining). See devdocs/secrets.md.
 export class Secret {
 	readonly keys: readonly string[];
 	constructor(
@@ -532,9 +528,8 @@ function secretValue(x: string | Secret): string {
 	return x instanceof Secret ? x.value : x;
 }
 
-// Wrap `value` as a tainted secret if any source was tainted, unioning the
-// source keys; otherwise return the plain string. This is how the string
-// primitives propagate taint through to their results.
+// Re-taint: if any source was a secret, wrap the result as a secret (unioning
+// keys); else return the plain string. How the string primitives propagate taint.
 function propagateTaint(
 	value: string,
 	sources: readonly unknown[],
@@ -544,24 +539,20 @@ function propagateTaint(
 	return keys.length > 0 ? new Secret(value, keys) : value;
 }
 
-// How a host supplies a secret: either just its value, or its value plus a
-// human-readable description shown by `(secrets)` so the LLM knows what it is.
+// A host-supplied secret: a bare value, or a value plus a description shown by
+// `(secrets)`.
 export type SecretSpec = string | { value: string; description?: string };
 
-// Required prefix for every registry key. Only `REPL_*` names become secrets,
-// and the prefix is kept, so `REPL_LINEAR_API_KEY` is read back as the secret
-// keyed `REPL_LINEAR_API_KEY` (both from env vars and host-supplied records).
+// Required prefix for every registry key; kept as part of the key. See
+// devdocs/secrets.md.
 const SECRET_ENV_PREFIX = "REPL_";
 
 export class Interp {
 	// Table of the global values of symbols
 	private readonly globals: Map<Sym, unknown> = new Map();
 
-	// Host-supplied secret registry: key -> { value, description }. Keys and
-	// descriptions are listable by the LLM (`(secrets)`); values are only
-	// obtainable as tainted `Secret` strings via `(secret "key")` and are never
-	// printed. Seeded from `REPL_*` env vars at construction (no description);
-	// `setSecrets` (from the host) overrides those and can attach descriptions.
+	// Host-supplied secret registry: key -> { value, description }. Seeded from
+	// `REPL_*` env vars; `setSecrets` overrides. See devdocs/secrets.md.
 	private readonly secrets: Map<
 		string,
 		{ value: string; description: string }
@@ -1021,8 +1012,7 @@ export class Interp {
 			},
 		);
 
-		// --- Secret registry (see the `Secret` class). Keys are readable by the
-		// LLM; values are opaque and only usable inside outgoing MCP calls.
+		// --- Secret registry. See devdocs/secrets.md.
 		this.seedSecretsFromEnv();
 		this.def(
 			"secrets",
@@ -1094,11 +1084,8 @@ export class Interp {
 		return this.globals.has(sym);
 	}
 
-	// Merge host-supplied secrets into the registry, overriding any existing
-	// (e.g. env-seeded) entries with the same key. Only keys starting with the
-	// `REPL_` prefix are accepted; the prefix is kept as part of the key, so a
-	// secret is read back with its full name, e.g. `(secret "REPL_LINEAR_API_KEY")`.
-	// Each spec is either a bare value or `{ value, description }`.
+	// Merge host secrets into the registry (later wins). Only `REPL_`-prefixed
+	// keys are accepted; each spec is a bare value or `{ value, description }`.
 	setSecrets(record: Record<string, SecretSpec>): void {
 		for (const [key, spec] of Object.entries(record)) {
 			if (!key.startsWith(SECRET_ENV_PREFIX)) continue;
@@ -1114,18 +1101,15 @@ export class Interp {
 		return [...this.secrets.keys()];
 	}
 
-	// Load secrets from a `.env`-style file (KEY=VALUE lines). Only `REPL_`-prefixed
-	// keys are registered (see setSecrets), and the prefix is kept as part of the
-	// key. Later calls / `setSecrets` win. Returns the parsed entries (so a host
-	// can persist them); throws if the file cannot be read.
+	// Load `REPL_*` secrets from a `.env` file; returns the parsed entries (so a
+	// host can persist them). Throws if the file cannot be read.
 	loadSecretsFromFile(path: string): Record<string, string> {
 		const record = dotenv.parse(readFileSync(path));
 		this.setSecrets(record);
 		return record;
 	}
 
-	// Seed the registry from `REPL_*` environment variables, keeping the prefix
-	// as part of the key (e.g. `REPL_LINEAR_API_KEY`).
+	// Seed the registry from `REPL_*` environment variables.
 	private seedSecretsFromEnv(): void {
 		for (const [name, value] of Object.entries(process.env)) {
 			if (value !== undefined && name.startsWith(SECRET_ENV_PREFIX))

--- a/packages/interpreter/src/lisp.ts
+++ b/packages/interpreter/src/lisp.ts
@@ -213,6 +213,13 @@ const zString = z.custom<string>(
 	(x) => typeof x === "string",
 	"string expected",
 );
+// Accepts a plain string or a tainted secret (see the `Secret` class). Used by
+// the string primitives so secrets flow through them; read the underlying text
+// with `secretValue` and re-taint the result with `propagateTaint`.
+const zStringLike = z.custom<string | Secret>(
+	(x) => typeof x === "string" || x instanceof Secret,
+	"string expected",
+);
 const zSym = z.custom<Sym>((x) => x instanceof Sym, "symbol expected");
 
 // Validate a built-in's argument frame against a tuple schema, throwing an
@@ -496,6 +503,47 @@ function listToStrings(list: List): string[] {
 	return out;
 }
 
+// A tainted string: the value of a secret, or anything derived from one. It
+// behaves like a string everywhere in the interpreter (the string primitives
+// accept it and propagate the taint into their results), but `str` renders it
+// redacted as `#<secret:KEY>` — so a secret and everything computed from it is
+// never printed, while the real value is still usable (revealed by `lispToJson`
+// when passed into an outgoing MCP call). `keys` records which registry secrets
+// it descends from (more than one after e.g. concatenating two secrets).
+export class Secret {
+	readonly keys: readonly string[];
+	constructor(
+		readonly value: string,
+		keys: Iterable<string>,
+	) {
+		this.keys = [...new Set(keys)];
+	}
+	// Length so the `length` primitive treats a secret like a string.
+	get length(): number {
+		return this.value.length;
+	}
+	toString(): string {
+		return `#<secret:${this.keys.join("+")}>`;
+	}
+}
+
+// The underlying string of a plain string or a tainted secret.
+function secretValue(x: string | Secret): string {
+	return x instanceof Secret ? x.value : x;
+}
+
+// Wrap `value` as a tainted secret if any source was tainted, unioning the
+// source keys; otherwise return the plain string. This is how the string
+// primitives propagate taint through to their results.
+function propagateTaint(
+	value: string,
+	sources: readonly unknown[],
+): string | Secret {
+	const keys: string[] = [];
+	for (const s of sources) if (s instanceof Secret) keys.push(...s.keys);
+	return keys.length > 0 ? new Secret(value, keys) : value;
+}
+
 // Required prefix for every registry key. Only `REPL_*` names become secrets,
 // and the prefix is kept, so `REPL_LINEAR_API_KEY` is read back as the secret
 // keyed `REPL_LINEAR_API_KEY` (both from env vars and host-supplied records).
@@ -612,8 +660,12 @@ export class Interp {
 			"(length x)",
 			"Return the length of a list or string.",
 			z.tuple([
-				z.custom<Cell | string | null>(
-					(x) => x === null || x instanceof Cell || typeof x === "string",
+				z.custom<Cell | string | Secret | null>(
+					(x) =>
+						x === null ||
+						x instanceof Cell ||
+						typeof x === "string" ||
+						x instanceof Secret,
 					"list or string expected",
 				),
 			]),
@@ -625,7 +677,7 @@ export class Interp {
 			"(stringp x)",
 			"Return t if `x` is a string.",
 			z.tuple([zAny]),
-			([x]) => (typeof x === "string" ? true : null),
+			([x]) => (typeof x === "string" || x instanceof Secret ? true : null),
 		);
 		this.def(
 			"numberp",
@@ -643,11 +695,14 @@ export class Interp {
 			"Return t if `x` and `y` are identical or numerically equal. Alias: `=`.",
 			z.tuple([zAny, zAny]),
 			([x, y]) => {
-				return x === y
-					? true
-					: isNumeric(x) && isNumeric(y) && compare(x, y) === 0
-						? true
-						: null;
+				if (x === y) return true;
+				if (isNumeric(x) && isNumeric(y) && compare(x, y) === 0) return true;
+				// Strings compare by value, so a tainted secret is equal to the
+				// plain string it holds (lets string predicates work on secrets).
+				const xs = typeof x === "string" || x instanceof Secret;
+				const ys = typeof y === "string" || y instanceof Secret;
+				if (xs && ys && secretValue(x) === secretValue(y)) return true;
+				return null;
 			},
 		);
 
@@ -836,26 +891,30 @@ export class Interp {
 			2,
 			"(char s i)",
 			"Return the character at index `i` of `s` as a one-character string, or nil if `i` is out of range.",
-			z.tuple([zString, zNumeric]),
+			z.tuple([zStringLike, zNumeric]),
 			([s, i]) => {
+				const v = secretValue(s);
 				const n = Number(i);
-				return n >= 0 && n < s.length ? s[n] : null;
+				return n >= 0 && n < v.length ? propagateTaint(v[n], [s]) : null;
 			},
 		);
 		this.def(
 			"concat",
 			-1,
 			"(concat s...)",
-			"Concatenate the string arguments into one string.",
+			"Concatenate the string arguments into one string. If any argument is a secret, the result is a secret too (its taint is carried through).",
 			z.tuple([zList]),
 			([rest]) => {
 				let out = "";
+				const sources: unknown[] = [];
 				for (let p = rest; p !== null; p = p.cdr as List) {
 					const s = (p as Cell).car;
-					if (typeof s !== "string") throw new EvalException("not a string", s);
-					out += s;
+					if (typeof s !== "string" && !(s instanceof Secret))
+						throw new EvalException("not a string", s);
+					sources.push(s);
+					out += secretValue(s);
 				}
-				return out;
+				return propagateTaint(out, sources);
 			},
 		);
 		this.def(
@@ -863,16 +922,16 @@ export class Interp {
 			1,
 			"(string-upcase s)",
 			"Return `s` with all letters converted to upper case.",
-			z.tuple([zString]),
-			([s]) => s.toUpperCase(),
+			z.tuple([zStringLike]),
+			([s]) => propagateTaint(secretValue(s).toUpperCase(), [s]),
 		);
 		this.def(
 			"string-downcase",
 			1,
 			"(string-downcase s)",
 			"Return `s` with all letters converted to lower case.",
-			z.tuple([zString]),
-			([s]) => s.toLowerCase(),
+			z.tuple([zStringLike]),
+			([s]) => propagateTaint(secretValue(s).toLowerCase(), [s]),
 		);
 
 		this.def(
@@ -975,13 +1034,13 @@ export class Interp {
 			"secret",
 			1,
 			"(secret key)",
-			"Return the secret stored under `key`. It is an ordinary string, so any text function works on it; the REPL redacts its value (as #<secret:key>) when printing results, so it is never shown. Errors if `key` is unknown.",
+			"Return the secret stored under `key` as a tainted string: every text function works on it and the taint follows into the result, but it always prints redacted (as #<secret:key>) and is only revealed when passed into a call such as an MCP tool or `:headers`. Errors if `key` is unknown.",
 			z.tuple([zString]),
 			([key]) => {
 				const value = this.secrets.get(key);
 				if (value === undefined)
 					throw new EvalException("unknown secret", key, false);
-				return value;
+				return new Secret(value, [key]);
 			},
 		);
 
@@ -1037,22 +1096,6 @@ export class Interp {
 	// The registry keys the LLM is allowed to see (values stay hidden).
 	secretKeys(): string[] {
 		return [...this.secrets.keys()];
-	}
-
-	// Redact secret values out of REPL-bound text. Secrets are ordinary strings
-	// inside the interpreter (so every text function works on them naturally);
-	// redaction is a presentation concern applied once, here, when the REPL is
-	// about to show output — replacing any occurrence of a secret's value with
-	// `#<secret:KEY>`. Longest values first so overlapping values mask fully.
-	redactSecrets(text: string): string {
-		let out = text;
-		const entries = [...this.secrets.entries()].sort(
-			(a, b) => b[1].length - a[1].length,
-		);
-		for (const [key, value] of entries) {
-			if (value.length > 0) out = out.split(value).join(`#<secret:${key}>`);
-		}
-		return out;
 	}
 
 	// Load secrets from a `.env`-style file (KEY=VALUE lines). Only `REPL_`-prefixed

--- a/packages/interpreter/src/lisp.ts
+++ b/packages/interpreter/src/lisp.ts
@@ -496,26 +496,9 @@ function listToStrings(list: List): string[] {
 	return out;
 }
 
-// An opaque secret value. It carries its registry key and its real value, but
-// only ever prints as `#<secret:KEY>` (via `str`'s toString fallback) so the
-// LLM can see a secret *exists* without reading it. The real value is revealed
-// only when a secret is serialized into an outgoing MCP request (see the
-// `Secret` branch in `lispToJson`, src/mcp.ts).
-export class Secret {
-	constructor(
-		readonly key: string,
-		private readonly value: string,
-	) {}
-	reveal(): string {
-		return this.value;
-	}
-	toString(): string {
-		return `#<secret:${this.key}>`;
-	}
-}
-
-// Prefix for environment variables seeded into the secret registry, e.g.
-// `REPL_LINEAR_API_KEY` becomes the secret keyed `LINEAR_API_KEY`.
+// Required prefix for every registry key. Only `REPL_*` names become secrets,
+// and the prefix is kept, so `REPL_LINEAR_API_KEY` is read back as the secret
+// keyed `REPL_LINEAR_API_KEY` (both from env vars and host-supplied records).
 const SECRET_ENV_PREFIX = "REPL_";
 
 export class Interp {
@@ -863,27 +846,16 @@ export class Interp {
 			"concat",
 			-1,
 			"(concat s...)",
-			'Concatenate the string arguments into one string. If any argument is a secret, the result is itself an opaque secret (redacted when printed, revealed only when passed into a call) so credentials like `(concat "Bearer " (secret "X"))` can be built without exposing the value.',
+			"Concatenate the string arguments into one string.",
 			z.tuple([zList]),
 			([rest]) => {
 				let out = "";
-				const secretKeys: string[] = [];
 				for (let p = rest; p !== null; p = p.cdr as List) {
 					const s = (p as Cell).car;
-					if (s instanceof Secret) {
-						secretKeys.push(s.key);
-						out += s.reveal();
-					} else if (typeof s === "string") {
-						out += s;
-					} else {
-						throw new EvalException("not a string", s);
-					}
+					if (typeof s !== "string") throw new EvalException("not a string", s);
+					out += s;
 				}
-				// Composing with a secret yields a secret, so the joined value stays
-				// opaque everywhere except the outgoing-request serialization.
-				return secretKeys.length > 0
-					? new Secret(secretKeys.join("+"), out)
-					: out;
+				return out;
 			},
 		);
 		this.def(
@@ -1003,13 +975,13 @@ export class Interp {
 			"secret",
 			1,
 			"(secret key)",
-			"Return the secret stored under `key` as an opaque value (prints as #<secret:key>). Its real value is never shown; it is only revealed when passed into a call such as an MCP tool or `:headers`. Errors if `key` is unknown.",
+			"Return the secret stored under `key`. It is an ordinary string, so any text function works on it; the REPL redacts its value (as #<secret:key>) when printing results, so it is never shown. Errors if `key` is unknown.",
 			z.tuple([zString]),
 			([key]) => {
 				const value = this.secrets.get(key);
 				if (value === undefined)
 					throw new EvalException("unknown secret", key, false);
-				return new Secret(key, value);
+				return value;
 			},
 		);
 
@@ -1054,10 +1026,12 @@ export class Interp {
 	}
 
 	// Merge host-supplied secrets into the registry, overriding any existing
-	// (e.g. env-seeded) entries with the same key.
+	// (e.g. env-seeded) entries with the same key. Only keys starting with the
+	// `REPL_` prefix are accepted; the prefix is kept as part of the key, so a
+	// secret is read back with its full name, e.g. `(secret "REPL_LINEAR_API_KEY")`.
 	setSecrets(record: Record<string, string>): void {
 		for (const [key, value] of Object.entries(record))
-			this.secrets.set(key, value);
+			if (key.startsWith(SECRET_ENV_PREFIX)) this.secrets.set(key, value);
 	}
 
 	// The registry keys the LLM is allowed to see (values stay hidden).
@@ -1065,21 +1039,38 @@ export class Interp {
 		return [...this.secrets.keys()];
 	}
 
-	// Load secrets from a `.env`-style file (KEY=VALUE lines). Every entry is
-	// registered as a secret under its literal key, overriding existing entries.
-	// Later calls / `setSecrets` win. Returns the parsed entries (so a host can
-	// persist them); throws if the file cannot be read.
+	// Redact secret values out of REPL-bound text. Secrets are ordinary strings
+	// inside the interpreter (so every text function works on them naturally);
+	// redaction is a presentation concern applied once, here, when the REPL is
+	// about to show output — replacing any occurrence of a secret's value with
+	// `#<secret:KEY>`. Longest values first so overlapping values mask fully.
+	redactSecrets(text: string): string {
+		let out = text;
+		const entries = [...this.secrets.entries()].sort(
+			(a, b) => b[1].length - a[1].length,
+		);
+		for (const [key, value] of entries) {
+			if (value.length > 0) out = out.split(value).join(`#<secret:${key}>`);
+		}
+		return out;
+	}
+
+	// Load secrets from a `.env`-style file (KEY=VALUE lines). Only `REPL_`-prefixed
+	// keys are registered (see setSecrets), and the prefix is kept as part of the
+	// key. Later calls / `setSecrets` win. Returns the parsed entries (so a host
+	// can persist them); throws if the file cannot be read.
 	loadSecretsFromFile(path: string): Record<string, string> {
 		const record = dotenv.parse(readFileSync(path));
 		this.setSecrets(record);
 		return record;
 	}
 
-	// Seed the registry from `LISPTC_SECRET_*` environment variables.
+	// Seed the registry from `REPL_*` environment variables, keeping the prefix
+	// as part of the key (e.g. `REPL_LINEAR_API_KEY`).
 	private seedSecretsFromEnv(): void {
 		for (const [name, value] of Object.entries(process.env)) {
 			if (value !== undefined && name.startsWith(SECRET_ENV_PREFIX))
-				this.secrets.set(name.slice(SECRET_ENV_PREFIX.length), value);
+				this.secrets.set(name, value);
 		}
 	}
 

--- a/packages/interpreter/src/lisp.ts
+++ b/packages/interpreter/src/lisp.ts
@@ -4,6 +4,7 @@
 
 import { readFileSync } from "node:fs";
 import { dirname, resolve as resolvePath } from "node:path";
+import * as dotenv from "dotenv";
 import { z } from "zod";
 import {
 	add,
@@ -495,9 +496,37 @@ function listToStrings(list: List): string[] {
 	return out;
 }
 
+// An opaque secret value. It carries its registry key and its real value, but
+// only ever prints as `#<secret:KEY>` (via `str`'s toString fallback) so the
+// LLM can see a secret *exists* without reading it. The real value is revealed
+// only when a secret is serialized into an outgoing MCP request (see the
+// `Secret` branch in `lispToJson`, src/mcp.ts).
+export class Secret {
+	constructor(
+		readonly key: string,
+		private readonly value: string,
+	) {}
+	reveal(): string {
+		return this.value;
+	}
+	toString(): string {
+		return `#<secret:${this.key}>`;
+	}
+}
+
+// Prefix for environment variables seeded into the secret registry, e.g.
+// `LISPTC_SECRET_LINEAR_API_KEY` becomes the secret keyed `LINEAR_API_KEY`.
+const SECRET_ENV_PREFIX = "LISPTC_SECRET_";
+
 export class Interp {
 	// Table of the global values of symbols
 	private readonly globals: Map<Sym, unknown> = new Map();
+
+	// Host-supplied secret registry: key -> real value. Keys are listable by the
+	// LLM (`(secrets)`); values are only obtainable as opaque `Secret` objects
+	// via `(secret "key")` and are never printed. Seeded from `LISPTC_SECRET_*`
+	// env vars at construction; `setSecrets` (from the host) overrides those.
+	private readonly secrets: Map<string, string> = new Map();
 
 	// Directories to resolve relative `import` paths against — one entry per
 	// file currently being loaded (the innermost import wins). Empty at the REPL,
@@ -942,6 +971,37 @@ export class Interp {
 			},
 		);
 
+		// --- Secret registry (see the `Secret` class). Keys are readable by the
+		// LLM; values are opaque and only usable inside outgoing MCP calls.
+		this.seedSecretsFromEnv();
+		this.def(
+			"secrets",
+			0,
+			"(secrets)",
+			"Return the list of available secret keys. Values are hidden — read a secret with `(secret key)`.",
+			z.tuple([]),
+			() => {
+				let list: List = null;
+				const keys = this.secretKeys();
+				for (let i = keys.length - 1; i >= 0; i--)
+					list = new Cell(keys[i], list);
+				return list;
+			},
+		);
+		this.def(
+			"secret",
+			1,
+			"(secret key)",
+			"Return the secret stored under `key` as an opaque value (prints as #<secret:key>). Its real value is never shown; it is only revealed when passed into a call such as an MCP tool or `:headers`. Errors if `key` is unknown.",
+			z.tuple([zString]),
+			([key]) => {
+				const value = this.secrets.get(key);
+				if (value === undefined)
+					throw new EvalException("unknown secret", key, false);
+				return new Secret(key, value);
+			},
+		);
+
 		// Install native MCP built-ins (load-mcp, unload-mcp, list-tools, ...).
 		registerMcp(this);
 	}
@@ -980,6 +1040,36 @@ export class Interp {
 
 	hasGlobal(sym: Sym): boolean {
 		return this.globals.has(sym);
+	}
+
+	// Merge host-supplied secrets into the registry, overriding any existing
+	// (e.g. env-seeded) entries with the same key.
+	setSecrets(record: Record<string, string>): void {
+		for (const [key, value] of Object.entries(record))
+			this.secrets.set(key, value);
+	}
+
+	// The registry keys the LLM is allowed to see (values stay hidden).
+	secretKeys(): string[] {
+		return [...this.secrets.keys()];
+	}
+
+	// Load secrets from a `.env`-style file (KEY=VALUE lines). Every entry is
+	// registered as a secret under its literal key, overriding existing entries.
+	// Later calls / `setSecrets` win. Returns the parsed entries (so a host can
+	// persist them); throws if the file cannot be read.
+	loadSecretsFromFile(path: string): Record<string, string> {
+		const record = dotenv.parse(readFileSync(path));
+		this.setSecrets(record);
+		return record;
+	}
+
+	// Seed the registry from `LISPTC_SECRET_*` environment variables.
+	private seedSecretsFromEnv(): void {
+		for (const [name, value] of Object.entries(process.env)) {
+			if (value !== undefined && name.startsWith(SECRET_ENV_PREFIX))
+				this.secrets.set(name.slice(SECRET_ENV_PREFIX.length), value);
+		}
 	}
 
 	// Build a BuiltInFunc without binding it (for wrappers stored elsewhere).

--- a/packages/interpreter/src/lisp.ts
+++ b/packages/interpreter/src/lisp.ts
@@ -515,8 +515,8 @@ export class Secret {
 }
 
 // Prefix for environment variables seeded into the secret registry, e.g.
-// `LISPTC_SECRET_LINEAR_API_KEY` becomes the secret keyed `LINEAR_API_KEY`.
-const SECRET_ENV_PREFIX = "LISPTC_SECRET_";
+// `REPL_LINEAR_API_KEY` becomes the secret keyed `LINEAR_API_KEY`.
+const SECRET_ENV_PREFIX = "REPL_";
 
 export class Interp {
 	// Table of the global values of symbols
@@ -524,8 +524,8 @@ export class Interp {
 
 	// Host-supplied secret registry: key -> real value. Keys are listable by the
 	// LLM (`(secrets)`); values are only obtainable as opaque `Secret` objects
-	// via `(secret "key")` and are never printed. Seeded from `LISPTC_SECRET_*`
-	// env vars at construction; `setSecrets` (from the host) overrides those.
+	// via `(secret "key")` and are never printed. Seeded from `REPL_*` env vars
+	// at construction; `setSecrets` (from the host) overrides those.
 	private readonly secrets: Map<string, string> = new Map();
 
 	// Directories to resolve relative `import` paths against — one entry per

--- a/packages/interpreter/src/lisp.ts
+++ b/packages/interpreter/src/lisp.ts
@@ -863,16 +863,27 @@ export class Interp {
 			"concat",
 			-1,
 			"(concat s...)",
-			"Concatenate the string arguments into one string.",
+			'Concatenate the string arguments into one string. If any argument is a secret, the result is itself an opaque secret (redacted when printed, revealed only when passed into a call) so credentials like `(concat "Bearer " (secret "X"))` can be built without exposing the value.',
 			z.tuple([zList]),
 			([rest]) => {
 				let out = "";
+				const secretKeys: string[] = [];
 				for (let p = rest; p !== null; p = p.cdr as List) {
 					const s = (p as Cell).car;
-					if (typeof s !== "string") throw new EvalException("not a string", s);
-					out += s;
+					if (s instanceof Secret) {
+						secretKeys.push(s.key);
+						out += s.reveal();
+					} else if (typeof s === "string") {
+						out += s;
+					} else {
+						throw new EvalException("not a string", s);
+					}
 				}
-				return out;
+				// Composing with a secret yields a secret, so the joined value stays
+				// opaque everywhere except the outgoing-request serialization.
+				return secretKeys.length > 0
+					? new Secret(secretKeys.join("+"), out)
+					: out;
 			},
 		);
 		this.def(

--- a/packages/interpreter/src/mcp-broker.ts
+++ b/packages/interpreter/src/mcp-broker.ts
@@ -35,6 +35,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { oauthEnv } from "@repo/env/oauth.ts";
 import {
+	type CallbackServer,
 	createAuthCallback,
 	FileOAuthStore,
 	StoredOAuthProvider,
@@ -87,40 +88,43 @@ class NeedsAuthError extends Error {
 	}
 }
 
-// Start the callback server (loopback locally, 0.0.0.0 behind an ingress) and,
-// in the background, exchange the captured code for tokens. Fire-and-forget;
-// silent on busy port / timeout (the manual mcp-authorize path still works).
-async function startCallbackCapture(
-	serverUrl: string,
-	scope: string | undefined,
-	authUrl: URL,
-): Promise<void> {
-	let cb: Awaited<ReturnType<typeof createAuthCallback>>;
+// A single long-lived callback server multiplexes every OAuth flow, so several
+// outstanding login links (e.g. from concurrent background `load-mcp` jobs) can
+// each complete independently. Lazily started; stays open (holding the fixed
+// redirect port) for the life of the broker.
+let callbackServer: CallbackServer | undefined;
+async function sharedCallbackServer(): Promise<CallbackServer | undefined> {
+	if (callbackServer) return callbackServer;
 	try {
-		cb = await createAuthCallback(
+		callbackServer = await createAuthCallback(
 			callbackPort(),
 			oauthEnv.LISPTC_OAUTH_REDIRECT_URL,
 		);
 	} catch {
-		return; // port busy: fall back to manual (mcp-authorize)
+		return undefined; // port busy (e.g. another lisptc): manual mcp-authorize
 	}
+	return callbackServer;
+}
+
+// Register this flow's callback capture. Fire-and-forget; silent on busy port /
+// timeout (the manual mcp-authorize path still works). The exchange uses THIS
+// flow's `provider` — whose in-memory PKCE verifier survives even after a later
+// login for the same server overwrites the stored one — so an earlier link's
+// code still exchanges correctly instead of failing PKCE.
+async function startCallbackCapture(
+	serverUrl: string,
+	scope: string | undefined,
+	authUrl: URL,
+	provider: StoredOAuthProvider,
+): Promise<void> {
+	const cb = await sharedCallbackServer();
+	if (!cb) return; // port busy: fall back to manual (mcp-authorize)
 	const state = authUrl.searchParams.get("state") ?? "";
-	cb.waitForCode(state)
-		.then(async (code) => {
-			const provider = await StoredOAuthProvider.create(
-				oauthStore,
-				serverUrl,
-				redirectUri(),
-				scope,
-			);
-			await auth(provider, {
-				serverUrl,
-				authorizationCode: code,
-				scope,
-			});
-		})
-		.catch(() => {}) // timeout / mismatch / exchange error: user can retry
-		.finally(() => cb.close());
+	cb.waitForCode(state, undefined, (code) =>
+		auth(provider, { serverUrl, authorizationCode: code, scope }).then(
+			() => {},
+		),
+	).catch(() => {}); // timeout / superseded / exchange error: surfaced in the browser page; user can retry
 }
 
 type Op =
@@ -429,7 +433,7 @@ async function ensureAuthorized(
 	await auth(provider, { serverUrl, scope });
 	const authUrl = provider.authorizationUrl;
 	if (!authUrl) throw new Error("no authorization URL produced");
-	void startCallbackCapture(serverUrl, scope, authUrl);
+	void startCallbackCapture(serverUrl, scope, authUrl, provider);
 	return { provider, authUrl: authUrl.href };
 }
 

--- a/packages/interpreter/src/mcp-broker.ts
+++ b/packages/interpreter/src/mcp-broker.ts
@@ -25,10 +25,15 @@ import { writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { parentPort } from "node:worker_threads";
+import {
+	auth,
+	UnauthorizedError,
+} from "@modelcontextprotocol/sdk/client/auth.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { FileOAuthStore, StoredOAuthProvider } from "./mcp-oauth.ts";
 
 // Reply states written into ctrl[0]. Must match src/mcp.ts.
 const STATE_DONE = 1;
@@ -37,7 +42,13 @@ const STATE_SPILL = 3; // reply too big for `data`; ctrl-length names a temp fil
 
 // A connection descriptor sent by the main thread.
 type ConnConfig =
-	| { name: string; url: string; headers?: Record<string, string> }
+	| {
+			name: string;
+			url: string;
+			headers?: Record<string, string>;
+			oauth?: boolean;
+			scopes?: string[];
+	  }
 	| {
 			name: string;
 			command: string;
@@ -45,8 +56,32 @@ type ConnConfig =
 			env?: Record<string, string>;
 	  };
 
+// OAuth token store shared across connections; swap in a DB-backed OAuthStore
+// here to persist tokens elsewhere.
+const oauthStore = new FileOAuthStore();
+
+// The redirect_uri registered with the authorization server. A fixed value (not
+// an ephemeral port) so the authorization request and the later code exchange
+// agree. Point it at your ingress callback in the cloud via env.
+function redirectUri(): string {
+	return (
+		process.env.LISPTC_OAUTH_REDIRECT_URL ?? "http://localhost:8909/callback"
+	);
+}
+
+// Thrown by connect() when a server needs interactive OAuth: its message carries
+// the authorization URL and the next step for the user.
+class NeedsAuthError extends Error {
+	constructor(server: string, authUrl: string) {
+		super(
+			`authorization required for "${server}": open ${authUrl} in a browser, approve, then run (mcp-authorize "${server}" "<code>")`,
+		);
+	}
+}
+
 type Op =
 	| "connect"
+	| "authorize"
 	| "list-tools"
 	| "call-tool"
 	| "disconnect"
@@ -163,6 +198,10 @@ async function dispatch(
 	switch (op) {
 		case "connect":
 			return connect(payload as ConnConfig, signal);
+		case "authorize":
+			return authorize(
+				payload as { url: string; code: string; scopes?: string[] },
+			);
 		case "list-tools":
 			return listTools((payload as { serverId: string }).serverId);
 		case "call-tool":
@@ -232,29 +271,54 @@ async function connect(
 	conf: ConnConfig,
 	signal?: AbortSignal,
 ): Promise<{ serverId: string; tools: Tool[] }> {
-	const transport =
-		"url" in conf
-			? new StreamableHTTPClientTransport(new URL(conf.url), {
-					requestInit: conf.headers ? { headers: conf.headers } : undefined,
-				})
-			: new StdioClientTransport({
-					command: conf.command,
-					args: conf.args ?? [],
-					// Inherit env so PATH etc. resolve; merge any explicit overrides.
-					env: {
-						...(process.env as Record<string, string>),
-						...(conf.env ?? {}),
-					},
-				});
-
 	const client = new Client(
 		{ name: "lisptc", version: "1.0.0" },
 		{ capabilities: {} },
 	);
+
 	// SDK performs the initialize + notifications/initialized handshake. The
 	// AbortSignal (from the job's AbortController) lets (cancel job) abort a
 	// slow connect/list mid-flight.
-	await client.connect(transport, { signal });
+	if ("url" in conf && conf.oauth) {
+		// OAuth 2.1 path. The provider supplies stored tokens (silently refreshing
+		// via the refresh token) so a returning session connects directly. With no
+		// usable token the SDK runs discovery + registration + PKCE, saves the code
+		// verifier, captures the authorization URL, and throws UnauthorizedError.
+		const scope = conf.scopes?.length ? conf.scopes.join(" ") : undefined;
+		const provider = await StoredOAuthProvider.create(
+			oauthStore,
+			conf.url,
+			redirectUri(),
+			scope,
+		);
+		const transport = new StreamableHTTPClientTransport(new URL(conf.url), {
+			authProvider: provider,
+		});
+		try {
+			await client.connect(transport, { signal });
+		} catch (e) {
+			if (!(e instanceof UnauthorizedError)) throw e;
+			const url = provider.authorizationUrl?.href;
+			if (!url) throw e;
+			throw new NeedsAuthError(conf.name, url);
+		}
+	} else {
+		const transport =
+			"url" in conf
+				? new StreamableHTTPClientTransport(new URL(conf.url), {
+						requestInit: conf.headers ? { headers: conf.headers } : undefined,
+					})
+				: new StdioClientTransport({
+						command: conf.command,
+						args: conf.args ?? [],
+						// Inherit env so PATH etc. resolve; merge any explicit overrides.
+						env: {
+							...(process.env as Record<string, string>),
+							...(conf.env ?? {}),
+						},
+					});
+		await client.connect(transport, { signal });
+	}
 	const { tools } = await client.listTools(undefined, { signal });
 	// A server that handshakes but exposes no tools is useless to lisptc (whose
 	// MCP integration is tools-only) — this is the common shape of a degraded /
@@ -268,6 +332,33 @@ async function connect(
 	const serverId = randomUUID();
 	clients.set(serverId, { client, tools });
 	return { serverId, tools };
+}
+
+// Complete an OAuth authorization: exchange the code the user brought back for
+// tokens (saved by the provider for reuse). Uses the PKCE verifier + client
+// registration persisted during connect(), so no live transport is needed —
+// which is what lets the code arrive out-of-band (loopback, manual paste, or a
+// cloud ingress). Afterwards a plain (load-mcp name) connects with the tokens.
+async function authorize(payload: {
+	url: string;
+	code: string;
+	scopes?: string[];
+}): Promise<{ ok: true }> {
+	const scope = payload.scopes?.length ? payload.scopes.join(" ") : undefined;
+	const provider = await StoredOAuthProvider.create(
+		oauthStore,
+		payload.url,
+		redirectUri(),
+		scope,
+	);
+	const result = await auth(provider, {
+		serverUrl: payload.url,
+		authorizationCode: payload.code,
+		scope,
+	});
+	if (result !== "AUTHORIZED")
+		throw new Error("authorization did not complete (unexpected redirect)");
+	return { ok: true };
 }
 
 async function listTools(serverId: string): Promise<Tool[]> {

--- a/packages/interpreter/src/mcp-broker.ts
+++ b/packages/interpreter/src/mcp-broker.ts
@@ -33,6 +33,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { oauthEnv } from "@repo/env/oauth.ts";
 import {
 	createAuthCallback,
 	FileOAuthStore,
@@ -65,13 +66,13 @@ const oauthStore = new FileOAuthStore();
 
 // Loopback callback port (local mode); fixed so the redirect URI is stable.
 function callbackPort(): number {
-	return Number(process.env.LISPTC_OAUTH_CALLBACK_PORT ?? 8909);
+	return oauthEnv.LISPTC_OAUTH_CALLBACK_PORT ?? 8909;
 }
 
 // Registered redirect_uri: cloud ingress URL, else the local loopback callback.
 function redirectUri(): string {
 	return (
-		process.env.LISPTC_OAUTH_REDIRECT_URL ??
+		oauthEnv.LISPTC_OAUTH_REDIRECT_URL ??
 		`http://127.0.0.1:${callbackPort()}/callback`
 	);
 }
@@ -96,7 +97,10 @@ async function startCallbackCapture(
 ): Promise<void> {
 	let cb: Awaited<ReturnType<typeof createAuthCallback>>;
 	try {
-		cb = await createAuthCallback(callbackPort());
+		cb = await createAuthCallback(
+			callbackPort(),
+			oauthEnv.LISPTC_OAUTH_REDIRECT_URL,
+		);
 	} catch {
 		return; // port busy: fall back to manual (mcp-authorize)
 	}

--- a/packages/interpreter/src/mcp-broker.ts
+++ b/packages/interpreter/src/mcp-broker.ts
@@ -121,6 +121,7 @@ async function startCallbackCapture(
 
 type Op =
 	| "connect"
+	| "login"
 	| "authorize"
 	| "logout"
 	| "list-tools"
@@ -239,6 +240,8 @@ async function dispatch(
 	switch (op) {
 		case "connect":
 			return connect(payload as ConnConfig, signal);
+		case "login":
+			return login(payload as { url: string; scopes?: string[] });
 		case "authorize":
 			return authorize(
 				payload as { url: string; code: string; scopes?: string[] },
@@ -324,43 +327,21 @@ async function connect(
 	// slow connect/list mid-flight.
 	if ("url" in conf && conf.oauth) {
 		// OAuth path: a stored token connects directly (auto-refreshed); with none
-		// the SDK runs discovery + registration + PKCE and throws
-		// UnauthorizedError. See devdocs/oauth.md.
+		// ensureAuthorized begins authorization and returns the login URL.
 		const scope = conf.scopes?.length ? conf.scopes.join(" ") : undefined;
-		const provider = await StoredOAuthProvider.create(
-			oauthStore,
-			conf.url,
-			redirectUri(),
-			scope,
-		);
-		// Drop a stale client registration bound to a different redirect URI so the
-		// SDK re-registers (else the server rejects "invalid redirect URI").
-		const registered = provider.clientInformation();
-		if (
-			registered?.redirect_uris &&
-			!registered.redirect_uris.includes(redirectUri())
-		) {
-			await provider.invalidateCredentials("all");
-		}
+		const { provider, authUrl } = await ensureAuthorized(conf.url, scope);
+		if (authUrl) throw new NeedsAuthError(conf.name, authUrl);
 		const transport = new StreamableHTTPClientTransport(new URL(conf.url), {
 			authProvider: provider,
 		});
-		// Begin authorization ourselves so our (valid, curated) `scope` is sent —
-		// the transport's own auth would request the server's entire
-		// scopes_supported list, which some servers reject as invalid_scope.
-		const beginAuth = async (): Promise<never> => {
-			await auth(provider, { serverUrl: conf.url, scope });
-			const authUrl = provider.authorizationUrl;
-			if (!authUrl) throw new Error("no authorization URL produced");
-			void startCallbackCapture(conf.url, scope, authUrl);
-			throw new NeedsAuthError(conf.name, authUrl.href);
-		};
-		if (!provider.tokens()) await beginAuth();
 		try {
 			await client.connect(transport, { signal });
 		} catch (e) {
-			if (e instanceof UnauthorizedError) await beginAuth();
-			throw e;
+			if (!(e instanceof UnauthorizedError)) throw e;
+			// Stored token rejected: drop it and re-authorize.
+			await provider.invalidateCredentials("tokens");
+			const retry = await ensureAuthorized(conf.url, scope);
+			throw new NeedsAuthError(conf.name, retry.authUrl ?? conf.url);
 		}
 	} else {
 		const transport =
@@ -416,6 +397,48 @@ async function authorize(payload: {
 	if (result !== "AUTHORIZED")
 		throw new Error("authorization did not complete (unexpected redirect)");
 	return { ok: true };
+}
+
+// Prepare an OAuth provider and, if there's no usable token, begin authorization
+// (with our curated `scope`, not the server's full scopes_supported which some
+// reject as invalid_scope) and start the callback capture. Returns the provider
+// and the login URL to open — or authUrl null if already authenticated.
+async function ensureAuthorized(
+	serverUrl: string,
+	scope: string | undefined,
+): Promise<{ provider: StoredOAuthProvider; authUrl: string | null }> {
+	const provider = await StoredOAuthProvider.create(
+		oauthStore,
+		serverUrl,
+		redirectUri(),
+		scope,
+	);
+	// Drop a stale client registration bound to a different redirect URI.
+	const registered = provider.clientInformation();
+	if (
+		registered?.redirect_uris &&
+		!registered.redirect_uris.includes(redirectUri())
+	) {
+		await provider.invalidateCredentials("all");
+	}
+	if (provider.tokens()) return { provider, authUrl: null };
+	await auth(provider, { serverUrl, scope });
+	const authUrl = provider.authorizationUrl;
+	if (!authUrl) throw new Error("no authorization URL produced");
+	void startCallbackCapture(serverUrl, scope, authUrl);
+	return { provider, authUrl: authUrl.href };
+}
+
+// Log in to an OAuth server: begin authorization and return the login URL to
+// open (null if already authenticated). The callback capture completes it in
+// the background, then (load-mcp) connects.
+async function login(payload: {
+	url: string;
+	scopes?: string[];
+}): Promise<{ authUrl: string | null }> {
+	const scope = payload.scopes?.length ? payload.scopes.join(" ") : undefined;
+	const { authUrl } = await ensureAuthorized(payload.url, scope);
+	return { authUrl };
 }
 
 // Delete a server's saved OAuth session (tokens, client registration, verifier)

--- a/packages/interpreter/src/mcp-broker.ts
+++ b/packages/interpreter/src/mcp-broker.ts
@@ -342,15 +342,22 @@ async function connect(
 		const transport = new StreamableHTTPClientTransport(new URL(conf.url), {
 			authProvider: provider,
 		});
+		// Begin authorization ourselves so our (valid, curated) `scope` is sent —
+		// the transport's own auth would request the server's entire
+		// scopes_supported list, which some servers reject as invalid_scope.
+		const beginAuth = async (): Promise<never> => {
+			await auth(provider, { serverUrl: conf.url, scope });
+			const authUrl = provider.authorizationUrl;
+			if (!authUrl) throw new Error("no authorization URL produced");
+			void startCallbackCapture(conf.url, scope, authUrl);
+			throw new NeedsAuthError(conf.name, authUrl.href);
+		};
+		if (!provider.tokens()) await beginAuth();
 		try {
 			await client.connect(transport, { signal });
 		} catch (e) {
-			if (!(e instanceof UnauthorizedError)) throw e;
-			const authUrl = provider.authorizationUrl;
-			if (!authUrl) throw e;
-			// Start the callback server to auto-capture the code (both modes).
-			void startCallbackCapture(conf.url, scope, authUrl);
-			throw new NeedsAuthError(conf.name, authUrl.href);
+			if (e instanceof UnauthorizedError) await beginAuth();
+			throw e;
 		}
 	} else {
 		const transport =

--- a/packages/interpreter/src/mcp-broker.ts
+++ b/packages/interpreter/src/mcp-broker.ts
@@ -34,8 +34,8 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import {
+	createAuthCallback,
 	FileOAuthStore,
-	LoopbackAuthCallback,
 	StoredOAuthProvider,
 } from "./mcp-oauth.ts";
 
@@ -76,31 +76,27 @@ function redirectUri(): string {
 	);
 }
 
-function isLocalCallback(): boolean {
-	return !process.env.LISPTC_OAUTH_REDIRECT_URL;
-}
-
 // Thrown by connect() when a server needs interactive OAuth; the message carries
 // the authorization URL and the next step.
 class NeedsAuthError extends Error {
-	constructor(server: string, authUrl: string, local: boolean) {
-		const next = local
-			? `after approving it will be captured automatically — then run (load-mcp "${server}") again`
-			: `approve, then run (mcp-authorize "${server}" "<code>")`;
-		super(`authorization required for "${server}": open ${authUrl} — ${next}`);
+	constructor(server: string, authUrl: string) {
+		super(
+			`authorization required for "${server}": open ${authUrl} — after approving it will be captured automatically, then run (load-mcp "${server}") again (or run (mcp-authorize "${server}" "<code>"))`,
+		);
 	}
 }
 
-// Start the loopback server and, in the background, exchange the captured code
-// for tokens. Fire-and-forget; silent on busy port / timeout (manual path works).
-async function startLoopbackCapture(
+// Start the callback server (loopback locally, 0.0.0.0 behind an ingress) and,
+// in the background, exchange the captured code for tokens. Fire-and-forget;
+// silent on busy port / timeout (the manual mcp-authorize path still works).
+async function startCallbackCapture(
 	serverUrl: string,
 	scope: string | undefined,
 	authUrl: URL,
 ): Promise<void> {
-	let cb: LoopbackAuthCallback;
+	let cb: Awaited<ReturnType<typeof createAuthCallback>>;
 	try {
-		cb = await LoopbackAuthCallback.start("/callback", callbackPort());
+		cb = await createAuthCallback(callbackPort());
 	} catch {
 		return; // port busy: fall back to manual (mcp-authorize)
 	}
@@ -352,10 +348,9 @@ async function connect(
 			if (!(e instanceof UnauthorizedError)) throw e;
 			const authUrl = provider.authorizationUrl;
 			if (!authUrl) throw e;
-			// Local mode: start the loopback server to auto-capture the code.
-			if (isLocalCallback())
-				void startLoopbackCapture(conf.url, scope, authUrl);
-			throw new NeedsAuthError(conf.name, authUrl.href, isLocalCallback());
+			// Start the callback server to auto-capture the code (both modes).
+			void startCallbackCapture(conf.url, scope, authUrl);
+			throw new NeedsAuthError(conf.name, authUrl.href);
 		}
 	} else {
 		const transport =

--- a/packages/interpreter/src/mcp-broker.ts
+++ b/packages/interpreter/src/mcp-broker.ts
@@ -33,7 +33,11 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
-import { FileOAuthStore, StoredOAuthProvider } from "./mcp-oauth.ts";
+import {
+	FileOAuthStore,
+	LoopbackAuthCallback,
+	StoredOAuthProvider,
+} from "./mcp-oauth.ts";
 
 // Reply states written into ctrl[0]. Must match src/mcp.ts.
 const STATE_DONE = 1;
@@ -60,23 +64,71 @@ type ConnConfig =
 // here to persist tokens elsewhere.
 const oauthStore = new FileOAuthStore();
 
-// The redirect_uri registered with the authorization server. A fixed value (not
-// an ephemeral port) so the authorization request and the later code exchange
-// agree. Point it at your ingress callback in the cloud via env.
+// Loopback callback port (local mode). Fixed so the redirect URI is stable and
+// the loopback server catches the redirect; override with env if 8909 clashes.
+function callbackPort(): number {
+	return Number(process.env.LISPTC_OAUTH_CALLBACK_PORT ?? 8909);
+}
+
+// The redirect_uri registered with the authorization server: a real ingress URL
+// in the cloud ($LISPTC_OAUTH_REDIRECT_URL), else the local loopback callback.
 function redirectUri(): string {
 	return (
-		process.env.LISPTC_OAUTH_REDIRECT_URL ?? "http://localhost:8909/callback"
+		process.env.LISPTC_OAUTH_REDIRECT_URL ??
+		`http://127.0.0.1:${callbackPort()}/callback`
 	);
 }
 
+// Whether we run the local loopback flow (no external ingress configured).
+function isLocalCallback(): boolean {
+	return !process.env.LISPTC_OAUTH_REDIRECT_URL;
+}
+
 // Thrown by connect() when a server needs interactive OAuth: its message carries
-// the authorization URL and the next step for the user.
+// the authorization URL and the next step. In local mode the loopback captures
+// the code automatically (just re-run load-mcp); otherwise paste it back.
 class NeedsAuthError extends Error {
-	constructor(server: string, authUrl: string) {
-		super(
-			`authorization required for "${server}": open ${authUrl} in a browser, approve, then run (mcp-authorize "${server}" "<code>")`,
-		);
+	constructor(server: string, authUrl: string, local: boolean) {
+		const next = local
+			? `after approving it will be captured automatically — then run (load-mcp "${server}") again`
+			: `approve, then run (mcp-authorize "${server}" "<code>")`;
+		super(`authorization required for "${server}": open ${authUrl} — ${next}`);
 	}
+}
+
+// Start the local loopback server and, in the background, exchange the code it
+// captures for tokens (saved for reuse). Fire-and-forget: the connect job has
+// already surfaced the URL; when the user approves, this completes the flow so a
+// subsequent (load-mcp) connects. Silent on a busy port / timeout — the manual
+// (mcp-authorize) path still works.
+async function startLoopbackCapture(
+	serverUrl: string,
+	scope: string | undefined,
+	authUrl: URL,
+): Promise<void> {
+	let cb: LoopbackAuthCallback;
+	try {
+		cb = await LoopbackAuthCallback.start("/callback", callbackPort());
+	} catch {
+		return; // port busy: fall back to manual (mcp-authorize)
+	}
+	const state = authUrl.searchParams.get("state") ?? "";
+	cb.waitForCode(state)
+		.then(async (code) => {
+			const provider = await StoredOAuthProvider.create(
+				oauthStore,
+				serverUrl,
+				redirectUri(),
+				scope,
+			);
+			await auth(provider, {
+				serverUrl,
+				authorizationCode: code,
+				scope,
+			});
+		})
+		.catch(() => {}) // timeout / mismatch / exchange error: user can retry
+		.finally(() => cb.close());
 }
 
 type Op =
@@ -298,9 +350,12 @@ async function connect(
 			await client.connect(transport, { signal });
 		} catch (e) {
 			if (!(e instanceof UnauthorizedError)) throw e;
-			const url = provider.authorizationUrl?.href;
-			if (!url) throw e;
-			throw new NeedsAuthError(conf.name, url);
+			const authUrl = provider.authorizationUrl;
+			if (!authUrl) throw e;
+			// Local mode: start the loopback server to auto-capture the code.
+			if (isLocalCallback())
+				void startLoopbackCapture(conf.url, scope, authUrl);
+			throw new NeedsAuthError(conf.name, authUrl.href, isLocalCallback());
 		}
 	} else {
 		const transport =

--- a/packages/interpreter/src/mcp-broker.ts
+++ b/packages/interpreter/src/mcp-broker.ts
@@ -122,6 +122,7 @@ async function startCallbackCapture(
 type Op =
 	| "connect"
 	| "authorize"
+	| "logout"
 	| "list-tools"
 	| "call-tool"
 	| "disconnect"
@@ -242,6 +243,8 @@ async function dispatch(
 			return authorize(
 				payload as { url: string; code: string; scopes?: string[] },
 			);
+		case "logout":
+			return logout(payload as { url: string });
 		case "list-tools":
 			return listTools((payload as { serverId: string }).serverId);
 		case "call-tool":
@@ -412,6 +415,13 @@ async function authorize(payload: {
 	});
 	if (result !== "AUTHORIZED")
 		throw new Error("authorization did not complete (unexpected redirect)");
+	return { ok: true };
+}
+
+// Delete a server's saved OAuth session (tokens, client registration, verifier)
+// via the store's clear(), so the next connect re-authorizes from scratch.
+async function logout(payload: { url: string }): Promise<{ ok: true }> {
+	await oauthStore.clear(new URL(payload.url).origin);
 	return { ok: true };
 }
 

--- a/packages/interpreter/src/mcp-broker.ts
+++ b/packages/interpreter/src/mcp-broker.ts
@@ -60,18 +60,15 @@ type ConnConfig =
 			env?: Record<string, string>;
 	  };
 
-// OAuth token store shared across connections; swap in a DB-backed OAuthStore
-// here to persist tokens elsewhere.
+// OAuth token store (swap for a DB-backed OAuthStore here). See devdocs/oauth.md.
 const oauthStore = new FileOAuthStore();
 
-// Loopback callback port (local mode). Fixed so the redirect URI is stable and
-// the loopback server catches the redirect; override with env if 8909 clashes.
+// Loopback callback port (local mode); fixed so the redirect URI is stable.
 function callbackPort(): number {
 	return Number(process.env.LISPTC_OAUTH_CALLBACK_PORT ?? 8909);
 }
 
-// The redirect_uri registered with the authorization server: a real ingress URL
-// in the cloud ($LISPTC_OAUTH_REDIRECT_URL), else the local loopback callback.
+// Registered redirect_uri: cloud ingress URL, else the local loopback callback.
 function redirectUri(): string {
 	return (
 		process.env.LISPTC_OAUTH_REDIRECT_URL ??
@@ -79,14 +76,12 @@ function redirectUri(): string {
 	);
 }
 
-// Whether we run the local loopback flow (no external ingress configured).
 function isLocalCallback(): boolean {
 	return !process.env.LISPTC_OAUTH_REDIRECT_URL;
 }
 
-// Thrown by connect() when a server needs interactive OAuth: its message carries
-// the authorization URL and the next step. In local mode the loopback captures
-// the code automatically (just re-run load-mcp); otherwise paste it back.
+// Thrown by connect() when a server needs interactive OAuth; the message carries
+// the authorization URL and the next step.
 class NeedsAuthError extends Error {
 	constructor(server: string, authUrl: string, local: boolean) {
 		const next = local
@@ -96,11 +91,8 @@ class NeedsAuthError extends Error {
 	}
 }
 
-// Start the local loopback server and, in the background, exchange the code it
-// captures for tokens (saved for reuse). Fire-and-forget: the connect job has
-// already surfaced the URL; when the user approves, this completes the flow so a
-// subsequent (load-mcp) connects. Silent on a busy port / timeout — the manual
-// (mcp-authorize) path still works.
+// Start the loopback server and, in the background, exchange the captured code
+// for tokens. Fire-and-forget; silent on busy port / timeout (manual path works).
 async function startLoopbackCapture(
 	serverUrl: string,
 	scope: string | undefined,
@@ -332,10 +324,9 @@ async function connect(
 	// AbortSignal (from the job's AbortController) lets (cancel job) abort a
 	// slow connect/list mid-flight.
 	if ("url" in conf && conf.oauth) {
-		// OAuth 2.1 path. The provider supplies stored tokens (silently refreshing
-		// via the refresh token) so a returning session connects directly. With no
-		// usable token the SDK runs discovery + registration + PKCE, saves the code
-		// verifier, captures the authorization URL, and throws UnauthorizedError.
+		// OAuth path: a stored token connects directly (auto-refreshed); with none
+		// the SDK runs discovery + registration + PKCE and throws
+		// UnauthorizedError. See devdocs/oauth.md.
 		const scope = conf.scopes?.length ? conf.scopes.join(" ") : undefined;
 		const provider = await StoredOAuthProvider.create(
 			oauthStore,
@@ -343,10 +334,8 @@ async function connect(
 			redirectUri(),
 			scope,
 		);
-		// Self-heal a stale dynamic-client registration: if the cached client was
-		// registered for a different redirect URI (e.g. the callback host/port
-		// changed), drop it so the SDK re-registers for the current one — otherwise
-		// the server rejects the authorize request with "invalid redirect URI".
+		// Drop a stale client registration bound to a different redirect URI so the
+		// SDK re-registers (else the server rejects "invalid redirect URI").
 		const registered = provider.clientInformation();
 		if (
 			registered?.redirect_uris &&
@@ -400,11 +389,8 @@ async function connect(
 	return { serverId, tools };
 }
 
-// Complete an OAuth authorization: exchange the code the user brought back for
-// tokens (saved by the provider for reuse). Uses the PKCE verifier + client
-// registration persisted during connect(), so no live transport is needed —
-// which is what lets the code arrive out-of-band (loopback, manual paste, or a
-// cloud ingress). Afterwards a plain (load-mcp name) connects with the tokens.
+// Exchange an authorization code for tokens using the persisted PKCE verifier +
+// client registration (no live transport needed). Then (load-mcp name) connects.
 async function authorize(payload: {
 	url: string;
 	code: string;

--- a/packages/interpreter/src/mcp-broker.ts
+++ b/packages/interpreter/src/mcp-broker.ts
@@ -343,6 +343,17 @@ async function connect(
 			redirectUri(),
 			scope,
 		);
+		// Self-heal a stale dynamic-client registration: if the cached client was
+		// registered for a different redirect URI (e.g. the callback host/port
+		// changed), drop it so the SDK re-registers for the current one — otherwise
+		// the server rejects the authorize request with "invalid redirect URI".
+		const registered = provider.clientInformation();
+		if (
+			registered?.redirect_uris &&
+			!registered.redirect_uris.includes(redirectUri())
+		) {
+			await provider.invalidateCredentials("all");
+		}
 		const transport = new StreamableHTTPClientTransport(new URL(conf.url), {
 			authProvider: provider,
 		});

--- a/packages/interpreter/src/mcp-oauth.ts
+++ b/packages/interpreter/src/mcp-oauth.ts
@@ -1,19 +1,7 @@
 /*
- * OAuth 2.1 support for remote (HTTP) MCP servers.
- *
- * Remote servers such as Linear speak OAuth 2.1 (PKCE + dynamic client
- * registration + metadata discovery). The MCP SDK implements the whole protocol
- * (`auth()` / the transport's `authProvider`); all we provide is:
- *
- *   1. persistence — where the client registration, tokens and PKCE verifier
- *      live between requests and sessions (so a token, once obtained, is reused
- *      and silently refreshed);
- *   2. redirect capture — grabbing the authorization URL the SDK builds so the
- *      broker can surface it to the user instead of opening a browser here.
- *
- * Persistence is behind the `OAuthStore` interface so the backing store is
- * swappable: a file-backed store ships now; a database-backed one can implement
- * the same interface later without touching the provider or the broker.
+ * OAuth 2.1 for remote MCP servers: token persistence (`OAuthStore` +
+ * `StoredOAuthProvider`) and redirect capture (`AuthCallback`). The MCP SDK
+ * implements the protocol itself. See devdocs/oauth.md.
  */
 
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
@@ -30,20 +18,13 @@ import type {
 
 // Everything persisted for one MCP server's OAuth session.
 export interface OAuthRecord {
-	// Result of dynamic client registration (client_id, and client_secret for
-	// confidential clients).
-	clientInformation?: OAuthClientInformationFull;
-	// Access + refresh tokens (with expiry). The refresh token is what lets a
-	// later session reconnect without sending the user through the browser again.
-	tokens?: OAuthTokens;
-	// PKCE code verifier, kept only for the brief window between building the
-	// authorization URL and exchanging the returned code.
-	codeVerifier?: string;
+	clientInformation?: OAuthClientInformationFull; // dynamic client registration
+	tokens?: OAuthTokens; // access + refresh (with expiry)
+	codeVerifier?: string; // PKCE, transient between auth URL and code exchange
 }
 
-// Swappable persistence for OAuth records, keyed by a stable per-server key
-// (the server origin). Async so a database-backed implementation fits the same
-// shape as the file-backed one.
+// Swappable persistence for OAuth records, keyed by server origin. Async so a
+// database-backed store fits the same shape as the file one.
 export interface OAuthStore {
 	load(serverKey: string): Promise<OAuthRecord | undefined>;
 	save(serverKey: string, record: OAuthRecord): Promise<void>;
@@ -63,9 +44,7 @@ function keyToFileName(serverKey: string): string {
 	return `${serverKey.replace(/[^a-zA-Z0-9._-]/g, "_")}.json`;
 }
 
-// A file-backed OAuthStore: one JSON file per server under a private directory
-// (0700 dir, 0600 files). This is the ships-now implementation; swap in a
-// database-backed OAuthStore later without changing anything else.
+// Default OAuthStore: one 0600 JSON file per server under a 0700 dir.
 export class FileOAuthStore implements OAuthStore {
 	constructor(private readonly dir: string = defaultOAuthDir()) {}
 
@@ -93,13 +72,10 @@ export class FileOAuthStore implements OAuthStore {
 	}
 }
 
-// An OAuthClientProvider (the SDK's storage/redirect hook) backed by an
-// OAuthStore. The record is hydrated once via `create`, held in memory so the
-// SDK's synchronous getters are cheap, and written through to the store on every
-// save. Construct one per connection with the chosen loopback redirect URL.
+// The SDK's storage/redirect hook, backed by an OAuthStore: hydrated once, held
+// in memory for the SDK's sync getters, written through on every save.
 export class StoredOAuthProvider implements OAuthClientProvider {
-	// The authorization URL the SDK asks us to send the user to. Captured rather
-	// than opened, so the broker can surface it (the `:needs-auth` job state).
+	// Captured (not opened) so the broker can surface it to the user.
 	authorizationUrl?: URL;
 
 	private constructor(
@@ -110,8 +86,7 @@ export class StoredOAuthProvider implements OAuthClientProvider {
 		private readonly scope: string | undefined,
 	) {}
 
-	// Hydrate the provider from the store for the given server + redirect URL.
-	// `scope` is the space-separated OAuth scopes to request (e.g. "read write").
+	// Hydrate from the store. `scope` is space-separated (e.g. "read write").
 	static async create(
 		store: OAuthStore,
 		serverUrl: string,
@@ -194,25 +169,13 @@ export class StoredOAuthProvider implements OAuthClientProvider {
 }
 
 // --- Authorization callback --------------------------------------------------
-//
-// Where the authorization server redirects after the user approves, and how the
-// resulting `code` gets back to the broker. This is a swappable seam like
-// `OAuthStore`: a loopback server is the right default for local/desktop use,
-// while a cloud deployment (behind a Kubernetes ingress with a real domain)
-// uses a fixed public redirect URL and delivers the code out-of-band. Nothing
-// here assumes localhost — the strategy is chosen by `createAuthCallback`.
+// Where the server redirects after approval, and how the `code` gets back. A
+// swappable seam: loopback for local use, external for cloud. See devdocs/oauth.md.
 
 export interface AuthCallback {
-	// The redirect_uri to register with the authorization server.
-	redirectUrl(): string;
-	// Resolve with the authorization code once it arrives, checking it carries
-	// the expected OAuth `state`. Rejects on timeout or state mismatch.
-	waitForCode(state: string, timeoutMs?: number): Promise<string>;
-	// Deliver a code obtained out-of-band — an ingress handler that terminates
-	// the public redirect, or the user pasting it via `(mcp-authorize)`. Both
-	// strategies accept this; loopback also fills it in automatically.
-	submitCode(params: { code: string; state?: string }): void;
-	// Release any resources (e.g. stop the loopback server).
+	redirectUrl(): string; // redirect_uri to register
+	waitForCode(state: string, timeoutMs?: number): Promise<string>; // rejects on timeout / state mismatch
+	submitCode(params: { code: string; state?: string }): void; // deliver an out-of-band code
 	close(): Promise<void>;
 }
 
@@ -257,9 +220,7 @@ abstract class BaseAuthCallback implements AuthCallback {
 	async close(): Promise<void> {}
 }
 
-// Local default: a transient HTTP server bound to 127.0.0.1 on an ephemeral
-// port that captures the redirect. Only reachable from a browser on the same
-// machine (never the network), and shut down once the code arrives.
+// Local: a transient 127.0.0.1 HTTP server that captures the redirect.
 export class LoopbackAuthCallback extends BaseAuthCallback {
 	private port = 0;
 
@@ -270,8 +231,8 @@ export class LoopbackAuthCallback extends BaseAuthCallback {
 		super();
 	}
 
-	// `port` 0 picks an ephemeral port; pass a fixed port to match a stable
-	// redirect URI. Rejects (e.g. EADDRINUSE) so the caller can fall back.
+	// `port` 0 is ephemeral; a fixed port matches a stable redirect URI. Rejects
+	// on EADDRINUSE so the caller can fall back.
 	static start(path = "/callback", port = 0): Promise<LoopbackAuthCallback> {
 		return new Promise((resolve, reject) => {
 			const server = createServer((req, res) => {
@@ -306,10 +267,8 @@ export class LoopbackAuthCallback extends BaseAuthCallback {
 	}
 }
 
-// Cloud/ingress default: no local server. The redirect points at a real domain
-// (your Kubernetes ingress, e.g. https://mcp.example.com/oauth/callback); the
-// handler behind that ingress — or the user via `(mcp-authorize)` — delivers
-// the code with `submitCode`.
+// Cloud/ingress: no local server. The redirect points at a real domain; the
+// ingress handler (or `(mcp-authorize)`) delivers the code via `submitCode`.
 export class ExternalAuthCallback extends BaseAuthCallback {
 	constructor(private readonly url: string) {
 		super();
@@ -319,9 +278,7 @@ export class ExternalAuthCallback extends BaseAuthCallback {
 	}
 }
 
-// Choose the callback strategy from configuration. Set
-// `LISPTC_OAUTH_REDIRECT_URL` to your ingress callback URL for a cloud
-// deployment; otherwise a loopback server is started for local use.
+// External if $LISPTC_OAUTH_REDIRECT_URL is set (cloud), else loopback (local).
 export function createAuthCallback(): Promise<AuthCallback> {
 	const external = process.env.LISPTC_OAUTH_REDIRECT_URL;
 	if (external) return Promise.resolve(new ExternalAuthCallback(external));

--- a/packages/interpreter/src/mcp-oauth.ts
+++ b/packages/interpreter/src/mcp-oauth.ts
@@ -270,8 +270,10 @@ export class LoopbackAuthCallback extends BaseAuthCallback {
 		super();
 	}
 
-	static start(path = "/callback"): Promise<LoopbackAuthCallback> {
-		return new Promise((resolve) => {
+	// `port` 0 picks an ephemeral port; pass a fixed port to match a stable
+	// redirect URI. Rejects (e.g. EADDRINUSE) so the caller can fall back.
+	static start(path = "/callback", port = 0): Promise<LoopbackAuthCallback> {
+		return new Promise((resolve, reject) => {
 			const server = createServer((req, res) => {
 				const url = new URL(req.url ?? "/", "http://127.0.0.1");
 				if (url.pathname !== path) {
@@ -282,12 +284,13 @@ export class LoopbackAuthCallback extends BaseAuthCallback {
 				const state = url.searchParams.get("state") ?? undefined;
 				res.writeHead(200, { "content-type": "text/html" });
 				res.end(
-					"<!doctype html><p>Authorization complete — you can close this tab.</p>",
+					"<!doctype html><p>Authorization complete — you can close this tab and return to the REPL.</p>",
 				);
 				if (code) cb.submitCode({ code, state });
 			});
 			const cb = new LoopbackAuthCallback(server, path);
-			server.listen(0, "127.0.0.1", () => {
+			server.once("error", reject);
+			server.listen(port, "127.0.0.1", () => {
 				cb.port = (server.address() as AddressInfo).port;
 				resolve(cb);
 			});

--- a/packages/interpreter/src/mcp-oauth.ts
+++ b/packages/interpreter/src/mcp-oauth.ts
@@ -16,6 +16,7 @@ import type {
 	OAuthClientMetadata,
 	OAuthTokens,
 } from "@modelcontextprotocol/sdk/shared/auth.js";
+import { oauthEnv } from "@repo/env/oauth.ts";
 
 // Everything persisted for one MCP server's OAuth session.
 export interface OAuthRecord {
@@ -35,8 +36,8 @@ export interface OAuthStore {
 // Default directory for the file store: $LISPTC_OAUTH_DIR, else
 // $XDG_CONFIG_HOME/lisptc/oauth, else ~/.config/lisptc/oauth.
 function defaultOAuthDir(): string {
-	if (process.env.LISPTC_OAUTH_DIR) return process.env.LISPTC_OAUTH_DIR;
-	const configHome = process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config");
+	if (oauthEnv.LISPTC_OAUTH_DIR) return oauthEnv.LISPTC_OAUTH_DIR;
+	const configHome = oauthEnv.XDG_CONFIG_HOME ?? join(homedir(), ".config");
 	return join(configHome, "lisptc", "oauth");
 }
 
@@ -291,19 +292,15 @@ export class CallbackServer extends BaseAuthCallback {
 	}
 }
 
-// Start the callback server for the current config on `port`. Behind an ingress
-// ($LISPTC_OAUTH_REDIRECT_URL) it binds 0.0.0.0 and advertises the public URL;
-// locally it binds 127.0.0.1.
-export function createAuthCallback(port: number): Promise<CallbackServer> {
-	const external = process.env.LISPTC_OAUTH_REDIRECT_URL;
-	if (external) {
-		const path = new URL(external).pathname || "/callback";
-		return CallbackServer.start({
-			host: "0.0.0.0",
-			port,
-			path,
-			redirectUrl: external,
-		});
+// With a public `redirectUrl` (an ingress) bind 0.0.0.0 and advertise it; else
+// loopback on 127.0.0.1. The broker passes the URL from the validated env.
+export function createAuthCallback(
+	port: number,
+	redirectUrl?: string,
+): Promise<CallbackServer> {
+	if (redirectUrl) {
+		const path = new URL(redirectUrl).pathname || "/callback";
+		return CallbackServer.start({ host: "0.0.0.0", port, path, redirectUrl });
 	}
 	return CallbackServer.start({ host: "127.0.0.1", port, path: "/callback" });
 }

--- a/packages/interpreter/src/mcp-oauth.ts
+++ b/packages/interpreter/src/mcp-oauth.ts
@@ -1,0 +1,182 @@
+/*
+ * OAuth 2.1 support for remote (HTTP) MCP servers.
+ *
+ * Remote servers such as Linear speak OAuth 2.1 (PKCE + dynamic client
+ * registration + metadata discovery). The MCP SDK implements the whole protocol
+ * (`auth()` / the transport's `authProvider`); all we provide is:
+ *
+ *   1. persistence — where the client registration, tokens and PKCE verifier
+ *      live between requests and sessions (so a token, once obtained, is reused
+ *      and silently refreshed);
+ *   2. redirect capture — grabbing the authorization URL the SDK builds so the
+ *      broker can surface it to the user instead of opening a browser here.
+ *
+ * Persistence is behind the `OAuthStore` interface so the backing store is
+ * swappable: a file-backed store ships now; a database-backed one can implement
+ * the same interface later without touching the provider or the broker.
+ */
+
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
+import type {
+	OAuthClientInformationFull,
+	OAuthClientMetadata,
+	OAuthTokens,
+} from "@modelcontextprotocol/sdk/shared/auth.js";
+
+// Everything persisted for one MCP server's OAuth session.
+export interface OAuthRecord {
+	// Result of dynamic client registration (client_id, and client_secret for
+	// confidential clients).
+	clientInformation?: OAuthClientInformationFull;
+	// Access + refresh tokens (with expiry). The refresh token is what lets a
+	// later session reconnect without sending the user through the browser again.
+	tokens?: OAuthTokens;
+	// PKCE code verifier, kept only for the brief window between building the
+	// authorization URL and exchanging the returned code.
+	codeVerifier?: string;
+}
+
+// Swappable persistence for OAuth records, keyed by a stable per-server key
+// (the server origin). Async so a database-backed implementation fits the same
+// shape as the file-backed one.
+export interface OAuthStore {
+	load(serverKey: string): Promise<OAuthRecord | undefined>;
+	save(serverKey: string, record: OAuthRecord): Promise<void>;
+	clear(serverKey: string): Promise<void>;
+}
+
+// Default directory for the file store: $LISPTC_OAUTH_DIR, else
+// $XDG_CONFIG_HOME/lisptc/oauth, else ~/.config/lisptc/oauth.
+function defaultOAuthDir(): string {
+	if (process.env.LISPTC_OAUTH_DIR) return process.env.LISPTC_OAUTH_DIR;
+	const configHome = process.env.XDG_CONFIG_HOME ?? join(homedir(), ".config");
+	return join(configHome, "lisptc", "oauth");
+}
+
+// Turn a server key (origin URL) into a safe file name.
+function keyToFileName(serverKey: string): string {
+	return `${serverKey.replace(/[^a-zA-Z0-9._-]/g, "_")}.json`;
+}
+
+// A file-backed OAuthStore: one JSON file per server under a private directory
+// (0700 dir, 0600 files). This is the ships-now implementation; swap in a
+// database-backed OAuthStore later without changing anything else.
+export class FileOAuthStore implements OAuthStore {
+	constructor(private readonly dir: string = defaultOAuthDir()) {}
+
+	private file(serverKey: string): string {
+		return join(this.dir, keyToFileName(serverKey));
+	}
+
+	async load(serverKey: string): Promise<OAuthRecord | undefined> {
+		try {
+			return JSON.parse(await readFile(this.file(serverKey), "utf8"));
+		} catch {
+			return undefined; // missing or unreadable => no stored session yet
+		}
+	}
+
+	async save(serverKey: string, record: OAuthRecord): Promise<void> {
+		await mkdir(this.dir, { recursive: true, mode: 0o700 });
+		await writeFile(this.file(serverKey), JSON.stringify(record), {
+			mode: 0o600,
+		});
+	}
+
+	async clear(serverKey: string): Promise<void> {
+		await rm(this.file(serverKey), { force: true });
+	}
+}
+
+// An OAuthClientProvider (the SDK's storage/redirect hook) backed by an
+// OAuthStore. The record is hydrated once via `create`, held in memory so the
+// SDK's synchronous getters are cheap, and written through to the store on every
+// save. Construct one per connection with the chosen loopback redirect URL.
+export class StoredOAuthProvider implements OAuthClientProvider {
+	// The authorization URL the SDK asks us to send the user to. Captured rather
+	// than opened, so the broker can surface it (the `:needs-auth` job state).
+	authorizationUrl?: URL;
+
+	private constructor(
+		private readonly store: OAuthStore,
+		private readonly serverKey: string,
+		private readonly redirect: string,
+		private readonly record: OAuthRecord,
+	) {}
+
+	// Hydrate the provider from the store for the given server + loopback URL.
+	static async create(
+		store: OAuthStore,
+		serverUrl: string,
+		redirectUrl: string,
+	): Promise<StoredOAuthProvider> {
+		const serverKey = new URL(serverUrl).origin;
+		const record = (await store.load(serverKey)) ?? {};
+		return new StoredOAuthProvider(store, serverKey, redirectUrl, record);
+	}
+
+	get redirectUrl(): string {
+		return this.redirect;
+	}
+
+	get clientMetadata(): OAuthClientMetadata {
+		return {
+			client_name: "lisptc",
+			redirect_uris: [this.redirect],
+			grant_types: ["authorization_code", "refresh_token"],
+			response_types: ["code"],
+			token_endpoint_auth_method: "none",
+		};
+	}
+
+	clientInformation(): OAuthClientInformationFull | undefined {
+		return this.record.clientInformation;
+	}
+
+	async saveClientInformation(info: OAuthClientInformationFull): Promise<void> {
+		this.record.clientInformation = info;
+		await this.persist();
+	}
+
+	tokens(): OAuthTokens | undefined {
+		return this.record.tokens;
+	}
+
+	async saveTokens(tokens: OAuthTokens): Promise<void> {
+		this.record.tokens = tokens;
+		await this.persist();
+	}
+
+	codeVerifier(): string {
+		if (this.record.codeVerifier === undefined)
+			throw new Error("no PKCE code verifier stored");
+		return this.record.codeVerifier;
+	}
+
+	async saveCodeVerifier(verifier: string): Promise<void> {
+		this.record.codeVerifier = verifier;
+		await this.persist();
+	}
+
+	redirectToAuthorization(authorizationUrl: URL): void {
+		this.authorizationUrl = authorizationUrl;
+	}
+
+	async invalidateCredentials(
+		scope: "all" | "client" | "tokens" | "verifier" | "discovery",
+	): Promise<void> {
+		if (scope === "all" || scope === "tokens") this.record.tokens = undefined;
+		if (scope === "all" || scope === "client")
+			this.record.clientInformation = undefined;
+		if (scope === "all" || scope === "verifier")
+			this.record.codeVerifier = undefined;
+		await this.persist();
+	}
+
+	private async persist(): Promise<void> {
+		await this.store.save(this.serverKey, this.record);
+	}
+}

--- a/packages/interpreter/src/mcp-oauth.ts
+++ b/packages/interpreter/src/mcp-oauth.ts
@@ -1,12 +1,12 @@
 /*
  * OAuth 2.1 for remote MCP servers: token persistence (`OAuthStore` +
- * `StoredOAuthProvider`) and redirect capture (`AuthCallback`). The MCP SDK
+ * `StoredOAuthProvider`) and redirect capture (`CallbackServer`). The MCP SDK
  * implements the protocol itself. See devdocs/oauth.md.
  */
 
 import { randomUUID } from "node:crypto";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
-import { createServer, type Server } from "node:http";
+import { createServer, type Server, type ServerResponse } from "node:http";
 import type { AddressInfo } from "node:net";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -178,54 +178,29 @@ export class StoredOAuthProvider implements OAuthClientProvider {
 }
 
 // --- Authorization callback --------------------------------------------------
-// Captures the redirect and hands the `code` back. See devdocs/oauth.md.
-
-interface AuthCallback {
-	redirectUrl(): string; // redirect_uri to register
-	waitForCode(state: string, timeoutMs?: number): Promise<string>; // rejects on timeout / state mismatch
-	submitCode(params: { code: string; state?: string }): void; // deliver an out-of-band code
-	close(): Promise<void>;
-}
+// Captures the redirect, runs the caller's token exchange, and reports the real
+// outcome to both the REPL and the browser tab. See devdocs/oauth.md.
 
 const DEFAULT_AUTH_TIMEOUT_MS = 300_000; // 5 min for the user to authorize
 
-// Shared waiting logic: a single pending authorization resolved by `submitCode`.
-abstract class BaseAuthCallback implements AuthCallback {
-	private pending?: {
-		state: string;
-		resolve: (code: string) => void;
-		reject: (err: Error) => void;
-		timer: ReturnType<typeof setTimeout>;
-	};
+// The caller's completion for one flow: exchange `code` for tokens. It runs
+// BEFORE the browser page is rendered, so the page never claims success for a
+// code that fails to exchange. Throwing produces an error page + a rejected wait.
+type CodeExchange = (code: string) => Promise<void>;
 
-	abstract redirectUrl(): string;
+interface Pending {
+	resolve: (code: string) => void;
+	reject: (err: Error) => void;
+	timer: ReturnType<typeof setTimeout>;
+	exchange?: CodeExchange;
+}
 
-	waitForCode(
-		state: string,
-		timeoutMs: number = DEFAULT_AUTH_TIMEOUT_MS,
-	): Promise<string> {
-		return new Promise<string>((resolve, reject) => {
-			const timer = setTimeout(() => {
-				this.pending = undefined;
-				reject(new Error("authorization timed out"));
-			}, timeoutMs);
-			this.pending = { state, resolve, reject, timer };
-		});
-	}
-
-	submitCode({ code, state }: { code: string; state?: string }): void {
-		const pending = this.pending;
-		if (!pending) return; // nothing waiting (late or duplicate callback)
-		this.pending = undefined;
-		clearTimeout(pending.timer);
-		if (state !== undefined && state !== pending.state) {
-			pending.reject(new Error("authorization state mismatch"));
-			return;
-		}
-		pending.resolve(code);
-	}
-
-	async close(): Promise<void> {}
+// Minimal HTML-escape for embedding an error message in the callback page.
+function escapeHtml(s: string): string {
+	return s.replace(
+		/[&<>]/g,
+		(c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;" })[c] as string,
+	);
 }
 
 // An HTTP server that captures the redirect. The same server handles both
@@ -235,16 +210,22 @@ abstract class BaseAuthCallback implements AuthCallback {
 //              domain URL ($LISPTC_OAUTH_REDIRECT_URL)
 // The advertised redirect URL can differ from the bind host:port (the ingress
 // bridges the public URL to the pod's 0.0.0.0:<port>).
-export class CallbackServer extends BaseAuthCallback {
+//
+// A single long-lived server multiplexes concurrent authorizations, routing each
+// callback to the flow that owns its OAuth `state`. This is why several
+// outstanding login links (e.g. one per background `load-mcp`) can each complete
+// independently instead of clobbering a single shared slot.
+export class CallbackServer {
 	private boundPort = 0;
+	// Pending authorizations keyed by OAuth `state` (a per-flow nonce). Routing by
+	// state keeps a stray or superseded callback from resolving the wrong flow.
+	private readonly pending = new Map<string, Pending>();
 
 	private constructor(
 		private readonly server: Server,
 		private readonly path: string,
 		private readonly advertised: string | undefined,
-	) {
-		super();
-	}
+	) {}
 
 	// Rejects on EADDRINUSE so the caller can fall back to (mcp-authorize).
 	static start(opts: {
@@ -266,13 +247,7 @@ export class CallbackServer extends BaseAuthCallback {
 					res.writeHead(404).end();
 					return;
 				}
-				const code = url.searchParams.get("code");
-				const state = url.searchParams.get("state") ?? undefined;
-				res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
-				res.end(
-					"<!doctype html><meta charset=utf-8><p>Authorization complete — you can close this tab and return to the REPL.</p>",
-				);
-				if (code) cb.submitCode({ code, state });
+				void cb.handle(url, res);
 			});
 			const cb = new CallbackServer(server, path, redirectUrl);
 			server.once("error", reject);
@@ -283,11 +258,89 @@ export class CallbackServer extends BaseAuthCallback {
 		});
 	}
 
+	private page(res: ServerResponse, status: number, body: string): void {
+		res.writeHead(status, { "content-type": "text/html; charset=utf-8" });
+		res.end(`<!doctype html><meta charset=utf-8><p>${body}</p>`);
+	}
+
+	private async handle(url: URL, res: ServerResponse): Promise<void> {
+		const code = url.searchParams.get("code");
+		const state = url.searchParams.get("state") ?? "";
+		const oauthError = url.searchParams.get("error");
+		const entry = this.pending.get(state);
+		if (!entry) {
+			// No flow owns this state: an expired, unknown, or superseded link. Do
+			// NOT disturb any other pending flow.
+			this.page(
+				res,
+				400,
+				"This authorization link is unknown or has expired — start a new login from the REPL and open the latest link.",
+			);
+			return;
+		}
+		this.pending.delete(state);
+		clearTimeout(entry.timer);
+		if (oauthError || !code) {
+			const msg = oauthError ?? "the redirect carried no authorization code";
+			entry.reject(new Error(`authorization failed: ${msg}`));
+			this.page(res, 400, `Authorization failed: ${escapeHtml(msg)}.`);
+			return;
+		}
+		// Run the exchange BEFORE reporting success, so a code that fails to
+		// exchange (e.g. a superseded link) shows an error rather than a misleading
+		// "complete" page.
+		try {
+			if (entry.exchange) await entry.exchange(code);
+			entry.resolve(code);
+			this.page(
+				res,
+				200,
+				"Authorization complete — you can close this tab and return to the REPL.",
+			);
+		} catch (e) {
+			const msg = e instanceof Error ? e.message : String(e);
+			entry.reject(e instanceof Error ? e : new Error(msg));
+			this.page(
+				res,
+				400,
+				`Authorization failed: ${escapeHtml(msg)} — start a new login from the REPL and open the latest link.`,
+			);
+		}
+	}
+
+	// Register a flow. Resolves with the captured code once it arrives (and, if
+	// given, `exchange` has succeeded); rejects on timeout, OAuth error, or a
+	// failed exchange. A second registration for the same state supersedes the
+	// first (should not happen — state is a fresh nonce — but never leak a timer).
+	waitForCode(
+		state: string,
+		timeoutMs: number = DEFAULT_AUTH_TIMEOUT_MS,
+		exchange?: CodeExchange,
+	): Promise<string> {
+		return new Promise<string>((resolve, reject) => {
+			const prev = this.pending.get(state);
+			if (prev) {
+				clearTimeout(prev.timer);
+				prev.reject(new Error("authorization superseded"));
+			}
+			const timer = setTimeout(() => {
+				this.pending.delete(state);
+				reject(new Error("authorization timed out"));
+			}, timeoutMs);
+			this.pending.set(state, { resolve, reject, timer, exchange });
+		});
+	}
+
 	redirectUrl(): string {
 		return this.advertised ?? `http://127.0.0.1:${this.boundPort}${this.path}`;
 	}
 
-	override close(): Promise<void> {
+	close(): Promise<void> {
+		for (const p of this.pending.values()) {
+			clearTimeout(p.timer);
+			p.reject(new Error("callback server closed"));
+		}
+		this.pending.clear();
 		return new Promise((resolve) => this.server.close(() => resolve()));
 	}
 }

--- a/packages/interpreter/src/mcp-oauth.ts
+++ b/packages/interpreter/src/mcp-oauth.ts
@@ -107,17 +107,26 @@ export class StoredOAuthProvider implements OAuthClientProvider {
 		private readonly serverKey: string,
 		private readonly redirect: string,
 		private readonly record: OAuthRecord,
+		private readonly scope: string | undefined,
 	) {}
 
-	// Hydrate the provider from the store for the given server + loopback URL.
+	// Hydrate the provider from the store for the given server + redirect URL.
+	// `scope` is the space-separated OAuth scopes to request (e.g. "read write").
 	static async create(
 		store: OAuthStore,
 		serverUrl: string,
 		redirectUrl: string,
+		scope?: string,
 	): Promise<StoredOAuthProvider> {
 		const serverKey = new URL(serverUrl).origin;
 		const record = (await store.load(serverKey)) ?? {};
-		return new StoredOAuthProvider(store, serverKey, redirectUrl, record);
+		return new StoredOAuthProvider(
+			store,
+			serverKey,
+			redirectUrl,
+			record,
+			scope,
+		);
 	}
 
 	get redirectUrl(): string {
@@ -131,6 +140,7 @@ export class StoredOAuthProvider implements OAuthClientProvider {
 			grant_types: ["authorization_code", "refresh_token"],
 			response_types: ["code"],
 			token_endpoint_auth_method: "none",
+			...(this.scope ? { scope: this.scope } : {}),
 		};
 	}
 

--- a/packages/interpreter/src/mcp-oauth.ts
+++ b/packages/interpreter/src/mcp-oauth.ts
@@ -169,10 +169,9 @@ export class StoredOAuthProvider implements OAuthClientProvider {
 }
 
 // --- Authorization callback --------------------------------------------------
-// Where the server redirects after approval, and how the `code` gets back. A
-// swappable seam: loopback for local use, external for cloud. See devdocs/oauth.md.
+// Captures the redirect and hands the `code` back. See devdocs/oauth.md.
 
-export interface AuthCallback {
+interface AuthCallback {
 	redirectUrl(): string; // redirect_uri to register
 	waitForCode(state: string, timeoutMs?: number): Promise<string>; // rejects on timeout / state mismatch
 	submitCode(params: { code: string; state?: string }): void; // deliver an out-of-band code
@@ -220,20 +219,37 @@ abstract class BaseAuthCallback implements AuthCallback {
 	async close(): Promise<void> {}
 }
 
-// Local: a transient 127.0.0.1 HTTP server that captures the redirect.
-export class LoopbackAuthCallback extends BaseAuthCallback {
-	private port = 0;
+// An HTTP server that captures the redirect. The same server handles both
+// modes; only where it binds and the URL it advertises differ:
+//   - local:   bind 127.0.0.1, advertise http://127.0.0.1:<port>/callback
+//   - ingress: bind 0.0.0.0 (reachable via the ingress), advertise the public
+//              domain URL ($LISPTC_OAUTH_REDIRECT_URL)
+// The advertised redirect URL can differ from the bind host:port (the ingress
+// bridges the public URL to the pod's 0.0.0.0:<port>).
+export class CallbackServer extends BaseAuthCallback {
+	private boundPort = 0;
 
 	private constructor(
 		private readonly server: Server,
 		private readonly path: string,
+		private readonly advertised: string | undefined,
 	) {
 		super();
 	}
 
-	// `port` 0 is ephemeral; a fixed port matches a stable redirect URI. Rejects
-	// on EADDRINUSE so the caller can fall back.
-	static start(path = "/callback", port = 0): Promise<LoopbackAuthCallback> {
+	// Rejects on EADDRINUSE so the caller can fall back to (mcp-authorize).
+	static start(opts: {
+		host?: string;
+		port?: number;
+		path?: string;
+		redirectUrl?: string;
+	}): Promise<CallbackServer> {
+		const {
+			host = "127.0.0.1",
+			port = 0,
+			path = "/callback",
+			redirectUrl,
+		} = opts;
 		return new Promise((resolve, reject) => {
 			const server = createServer((req, res) => {
 				const url = new URL(req.url ?? "/", "http://127.0.0.1");
@@ -249,17 +265,17 @@ export class LoopbackAuthCallback extends BaseAuthCallback {
 				);
 				if (code) cb.submitCode({ code, state });
 			});
-			const cb = new LoopbackAuthCallback(server, path);
+			const cb = new CallbackServer(server, path, redirectUrl);
 			server.once("error", reject);
-			server.listen(port, "127.0.0.1", () => {
-				cb.port = (server.address() as AddressInfo).port;
+			server.listen(port, host, () => {
+				cb.boundPort = (server.address() as AddressInfo).port;
 				resolve(cb);
 			});
 		});
 	}
 
 	redirectUrl(): string {
-		return `http://127.0.0.1:${this.port}${this.path}`;
+		return this.advertised ?? `http://127.0.0.1:${this.boundPort}${this.path}`;
 	}
 
 	override close(): Promise<void> {
@@ -267,20 +283,19 @@ export class LoopbackAuthCallback extends BaseAuthCallback {
 	}
 }
 
-// Cloud/ingress: no local server. The redirect points at a real domain; the
-// ingress handler (or `(mcp-authorize)`) delivers the code via `submitCode`.
-export class ExternalAuthCallback extends BaseAuthCallback {
-	constructor(private readonly url: string) {
-		super();
-	}
-	redirectUrl(): string {
-		return this.url;
-	}
-}
-
-// External if $LISPTC_OAUTH_REDIRECT_URL is set (cloud), else loopback (local).
-export function createAuthCallback(): Promise<AuthCallback> {
+// Start the callback server for the current config on `port`. Behind an ingress
+// ($LISPTC_OAUTH_REDIRECT_URL) it binds 0.0.0.0 and advertises the public URL;
+// locally it binds 127.0.0.1.
+export function createAuthCallback(port: number): Promise<CallbackServer> {
 	const external = process.env.LISPTC_OAUTH_REDIRECT_URL;
-	if (external) return Promise.resolve(new ExternalAuthCallback(external));
-	return LoopbackAuthCallback.start();
+	if (external) {
+		const path = new URL(external).pathname || "/callback";
+		return CallbackServer.start({
+			host: "0.0.0.0",
+			port,
+			path,
+			redirectUrl: external,
+		});
+	}
+	return CallbackServer.start({ host: "127.0.0.1", port, path: "/callback" });
 }

--- a/packages/interpreter/src/mcp-oauth.ts
+++ b/packages/interpreter/src/mcp-oauth.ts
@@ -282,9 +282,9 @@ export class LoopbackAuthCallback extends BaseAuthCallback {
 				}
 				const code = url.searchParams.get("code");
 				const state = url.searchParams.get("state") ?? undefined;
-				res.writeHead(200, { "content-type": "text/html" });
+				res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
 				res.end(
-					"<!doctype html><p>Authorization complete — you can close this tab and return to the REPL.</p>",
+					"<!doctype html><meta charset=utf-8><p>Authorization complete — you can close this tab and return to the REPL.</p>",
 				);
 				if (code) cb.submitCode({ code, state });
 			});

--- a/packages/interpreter/src/mcp-oauth.ts
+++ b/packages/interpreter/src/mcp-oauth.ts
@@ -4,6 +4,7 @@
  * implements the protocol itself. See devdocs/oauth.md.
  */
 
+import { randomUUID } from "node:crypto";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { createServer, type Server } from "node:http";
 import type { AddressInfo } from "node:net";
@@ -77,6 +78,13 @@ export class FileOAuthStore implements OAuthStore {
 export class StoredOAuthProvider implements OAuthClientProvider {
 	// Captured (not opened) so the broker can surface it to the user.
 	authorizationUrl?: URL;
+	// OAuth `state`, stable per instance. Some servers (PostHog) reject an
+	// authorize request without one; the callback validates the returned value.
+	private _state?: string;
+	state(): string {
+		if (!this._state) this._state = randomUUID();
+		return this._state;
+	}
 
 	private constructor(
 		private readonly store: OAuthStore,

--- a/packages/interpreter/src/mcp-oauth.ts
+++ b/packages/interpreter/src/mcp-oauth.ts
@@ -17,6 +17,8 @@
  */
 
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js";
@@ -179,4 +181,136 @@ export class StoredOAuthProvider implements OAuthClientProvider {
 	private async persist(): Promise<void> {
 		await this.store.save(this.serverKey, this.record);
 	}
+}
+
+// --- Authorization callback --------------------------------------------------
+//
+// Where the authorization server redirects after the user approves, and how the
+// resulting `code` gets back to the broker. This is a swappable seam like
+// `OAuthStore`: a loopback server is the right default for local/desktop use,
+// while a cloud deployment (behind a Kubernetes ingress with a real domain)
+// uses a fixed public redirect URL and delivers the code out-of-band. Nothing
+// here assumes localhost — the strategy is chosen by `createAuthCallback`.
+
+export interface AuthCallback {
+	// The redirect_uri to register with the authorization server.
+	redirectUrl(): string;
+	// Resolve with the authorization code once it arrives, checking it carries
+	// the expected OAuth `state`. Rejects on timeout or state mismatch.
+	waitForCode(state: string, timeoutMs?: number): Promise<string>;
+	// Deliver a code obtained out-of-band — an ingress handler that terminates
+	// the public redirect, or the user pasting it via `(mcp-authorize)`. Both
+	// strategies accept this; loopback also fills it in automatically.
+	submitCode(params: { code: string; state?: string }): void;
+	// Release any resources (e.g. stop the loopback server).
+	close(): Promise<void>;
+}
+
+const DEFAULT_AUTH_TIMEOUT_MS = 300_000; // 5 min for the user to authorize
+
+// Shared waiting logic: a single pending authorization resolved by `submitCode`.
+abstract class BaseAuthCallback implements AuthCallback {
+	private pending?: {
+		state: string;
+		resolve: (code: string) => void;
+		reject: (err: Error) => void;
+		timer: ReturnType<typeof setTimeout>;
+	};
+
+	abstract redirectUrl(): string;
+
+	waitForCode(
+		state: string,
+		timeoutMs: number = DEFAULT_AUTH_TIMEOUT_MS,
+	): Promise<string> {
+		return new Promise<string>((resolve, reject) => {
+			const timer = setTimeout(() => {
+				this.pending = undefined;
+				reject(new Error("authorization timed out"));
+			}, timeoutMs);
+			this.pending = { state, resolve, reject, timer };
+		});
+	}
+
+	submitCode({ code, state }: { code: string; state?: string }): void {
+		const pending = this.pending;
+		if (!pending) return; // nothing waiting (late or duplicate callback)
+		this.pending = undefined;
+		clearTimeout(pending.timer);
+		if (state !== undefined && state !== pending.state) {
+			pending.reject(new Error("authorization state mismatch"));
+			return;
+		}
+		pending.resolve(code);
+	}
+
+	async close(): Promise<void> {}
+}
+
+// Local default: a transient HTTP server bound to 127.0.0.1 on an ephemeral
+// port that captures the redirect. Only reachable from a browser on the same
+// machine (never the network), and shut down once the code arrives.
+export class LoopbackAuthCallback extends BaseAuthCallback {
+	private port = 0;
+
+	private constructor(
+		private readonly server: Server,
+		private readonly path: string,
+	) {
+		super();
+	}
+
+	static start(path = "/callback"): Promise<LoopbackAuthCallback> {
+		return new Promise((resolve) => {
+			const server = createServer((req, res) => {
+				const url = new URL(req.url ?? "/", "http://127.0.0.1");
+				if (url.pathname !== path) {
+					res.writeHead(404).end();
+					return;
+				}
+				const code = url.searchParams.get("code");
+				const state = url.searchParams.get("state") ?? undefined;
+				res.writeHead(200, { "content-type": "text/html" });
+				res.end(
+					"<!doctype html><p>Authorization complete — you can close this tab.</p>",
+				);
+				if (code) cb.submitCode({ code, state });
+			});
+			const cb = new LoopbackAuthCallback(server, path);
+			server.listen(0, "127.0.0.1", () => {
+				cb.port = (server.address() as AddressInfo).port;
+				resolve(cb);
+			});
+		});
+	}
+
+	redirectUrl(): string {
+		return `http://127.0.0.1:${this.port}${this.path}`;
+	}
+
+	override close(): Promise<void> {
+		return new Promise((resolve) => this.server.close(() => resolve()));
+	}
+}
+
+// Cloud/ingress default: no local server. The redirect points at a real domain
+// (your Kubernetes ingress, e.g. https://mcp.example.com/oauth/callback); the
+// handler behind that ingress — or the user via `(mcp-authorize)` — delivers
+// the code with `submitCode`.
+export class ExternalAuthCallback extends BaseAuthCallback {
+	constructor(private readonly url: string) {
+		super();
+	}
+	redirectUrl(): string {
+		return this.url;
+	}
+}
+
+// Choose the callback strategy from configuration. Set
+// `LISPTC_OAUTH_REDIRECT_URL` to your ingress callback URL for a cloud
+// deployment; otherwise a loopback server is started for local use.
+export function createAuthCallback(): Promise<AuthCallback> {
+	const external = process.env.LISPTC_OAUTH_REDIRECT_URL;
+	if (external) return Promise.resolve(new ExternalAuthCallback(external));
+	return LoopbackAuthCallback.start();
 }

--- a/packages/interpreter/src/mcp.ts
+++ b/packages/interpreter/src/mcp.ts
@@ -70,9 +70,8 @@ type ConnConfig = { description?: string } & (
 			name: string;
 			url: string;
 			headers?: Record<string, string>;
-			// Remote servers that speak OAuth 2.1 (e.g. Linear). When set, the broker
-			// attaches an OAuth provider that stores/refreshes tokens; `scopes` are the
-			// space-separated scopes requested at authorization time.
+			// OAuth 2.1 servers (e.g. Linear); `scopes` are requested at auth time.
+			// See devdocs/oauth.md.
 			oauth?: boolean;
 			scopes?: string[];
 	  }
@@ -319,8 +318,7 @@ function lispToJson(x: unknown): unknown {
 	if (isNumeric(x)) return x;
 	if (x instanceof LispKeyword) return x.name;
 	if (x instanceof Sym) return x.name;
-	// A secret reveals its real (tainted) value here, on the way out into an MCP
-	// request/config (tool args, :headers, :env) — never through `str`.
+	// A secret reveals its value only here, into the outgoing MCP request.
 	if (x instanceof Secret) return x.value;
 	if (x instanceof Cell) {
 		if (isAlist(x)) {
@@ -656,9 +654,7 @@ export function registerMcp(interp: Interp): void {
 		([name]) => arrayToList(doUnload(interp, name)),
 	);
 
-	// (mcp-authorize "server" "code") -> :authorized
-	// Completes the OAuth flow for a server: hand back the authorization code
-	// from the login link, which is exchanged for tokens and saved for reuse.
+	// (mcp-authorize "server" "code") -> :authorized. See devdocs/oauth.md.
 	interp.def(
 		"mcp-authorize",
 		-1,

--- a/packages/interpreter/src/mcp.ts
+++ b/packages/interpreter/src/mcp.ts
@@ -679,6 +679,25 @@ export function registerMcp(interp: Interp): void {
 		},
 	);
 
+	// (logout "server") -> :logged-out. See devdocs/oauth.md.
+	interp.def(
+		"logout",
+		-1,
+		'(logout "server")',
+		'Log out of an OAuth MCP server: unload it if loaded and delete its saved tokens, so the next (load-mcp "server") re-authorizes.',
+		z.tuple([zList]),
+		([rest]) => {
+			const args = listToArray(rest);
+			const name = typeof args[0] === "string" ? args[0] : asName(args[0]);
+			const conf = predefined.get(name);
+			if (!conf || !("url" in conf))
+				throw new EvalException("unknown OAuth MCP server", name, false);
+			if (servers.has(name)) doUnload(interp, name);
+			mcpRequest("logout", { url: conf.url });
+			return newLispKeyword("logged-out");
+		},
+	);
+
 	// (list-mcps) -> ((name :loaded|:unloaded count) ...)
 	interp.def(
 		"list-mcps",

--- a/packages/interpreter/src/mcp.ts
+++ b/packages/interpreter/src/mcp.ts
@@ -24,6 +24,7 @@ import {
 	type List,
 	newLispKeyword,
 	newSym,
+	Secret,
 	Sym,
 	zList,
 } from "./lisp.ts";
@@ -309,6 +310,9 @@ function lispToJson(x: unknown): unknown {
 	if (isNumeric(x)) return x;
 	if (x instanceof LispKeyword) return x.name;
 	if (x instanceof Sym) return x.name;
+	// A secret reveals its real (tainted) value here, on the way out into an MCP
+	// request/config (tool args, :headers, :env) — never through `str`.
+	if (x instanceof Secret) return x.value;
 	if (x instanceof Cell) {
 		if (isAlist(x)) {
 			const obj: Record<string, unknown> = {};

--- a/packages/interpreter/src/mcp.ts
+++ b/packages/interpreter/src/mcp.ts
@@ -24,7 +24,6 @@ import {
 	type List,
 	newLispKeyword,
 	newSym,
-	Secret,
 	Sym,
 	zList,
 } from "./lisp.ts";
@@ -310,9 +309,6 @@ function lispToJson(x: unknown): unknown {
 	if (isNumeric(x)) return x;
 	if (x instanceof LispKeyword) return x.name;
 	if (x instanceof Sym) return x.name;
-	// A secret reveals its real value only here, on the way out into an MCP
-	// request/config (tool args, :headers, :env) — never through `str`.
-	if (x instanceof Secret) return x.reveal();
 	if (x instanceof Cell) {
 		if (isAlist(x)) {
 			const obj: Record<string, unknown> = {};

--- a/packages/interpreter/src/mcp.ts
+++ b/packages/interpreter/src/mcp.ts
@@ -129,6 +129,21 @@ function parseTimeout(x: unknown): number {
 	return ms;
 }
 
+// Pull the authorization `code` out of a pasted callback link, or accept a bare
+// code as-is. Users tend to copy the whole redirect URL (…/callback?code=…&state=…)
+// rather than just the code, which otherwise fails the token exchange.
+function extractAuthCode(raw: string): string {
+	const value = raw.trim();
+	try {
+		// A URL yields its `code` param (empty string if the redirect carried an
+		// error instead), never the raw URL as a bogus code.
+		return new URL(value).searchParams.get("code") ?? "";
+	} catch {
+		// not a URL: treat it as a bare code
+		return value;
+	}
+}
+
 // --- Module state ------------------------------------------------------------
 const servers = new Map<string, ServerRec>();
 const predefined = new Map<string, ConnConfig>();
@@ -659,16 +674,25 @@ export function registerMcp(interp: Interp): void {
 		"mcp-authorize",
 		-1,
 		'(mcp-authorize "server" "code")',
-		'Finish OAuth for a server: exchange the authorization `code` from its login link for tokens (saved for reuse). Then (load-mcp "server") connects directly.',
+		'Finish OAuth for a server: exchange the authorization `code` for tokens (saved for reuse). Accepts either the bare code or the whole pasted callback link. Then (load-mcp "server") connects directly.',
 		z.tuple([zList]),
 		([rest]) => {
 			const args = listToArray(rest);
 			const name = typeof args[0] === "string" ? args[0] : asName(args[0]);
-			const code = args[1];
-			if (typeof code !== "string")
+			const raw = args[1];
+			if (typeof raw !== "string")
 				throw new EvalException(
 					"mcp-authorize requires an authorization code string",
-					code ?? null,
+					raw ?? null,
+					false,
+				);
+			// Accept either a bare code or the whole pasted callback link
+			// (e.g. http://127.0.0.1:.../callback?code=…&state=…).
+			const code = extractAuthCode(raw);
+			if (!code)
+				throw new EvalException(
+					"no authorization code found in the pasted value",
+					raw,
 					false,
 				);
 			const conf = predefined.get(name);

--- a/packages/interpreter/src/mcp.ts
+++ b/packages/interpreter/src/mcp.ts
@@ -66,7 +66,16 @@ interface JsonSchema {
 }
 
 type ConnConfig = { description?: string } & (
-	| { name: string; url: string; headers?: Record<string, string> }
+	| {
+			name: string;
+			url: string;
+			headers?: Record<string, string>;
+			// Remote servers that speak OAuth 2.1 (e.g. Linear). When set, the broker
+			// attaches an OAuth provider that stores/refreshes tokens; `scopes` are the
+			// space-separated scopes requested at authorization time.
+			oauth?: boolean;
+			scopes?: string[];
+	  }
 	| {
 			name: string;
 			command: string;
@@ -424,7 +433,11 @@ function connConfigFromArgs(rest: List): ConnConfig {
 		const headers = opts.has("headers")
 			? (lispToJson(opts.get("headers")) as Record<string, string>)
 			: undefined;
-		return { name, url, headers };
+		const oauth = opts.has("oauth") ? opts.get("oauth") !== null : undefined;
+		const scopes = opts.has("scopes")
+			? listToArray(opts.get("scopes") as List).map(String)
+			: undefined;
+		return { name, url, headers, oauth, scopes };
 	}
 	if (opts.has("command")) {
 		const command = opts.get("command");
@@ -641,6 +654,33 @@ export function registerMcp(interp: Interp): void {
 		"Unload an MCP server and remove its `server/tool` bindings.",
 		z.tuple([zName]),
 		([name]) => arrayToList(doUnload(interp, name)),
+	);
+
+	// (mcp-authorize "server" "code") -> :authorized
+	// Completes the OAuth flow for a server: hand back the authorization code
+	// from the login link, which is exchanged for tokens and saved for reuse.
+	interp.def(
+		"mcp-authorize",
+		-1,
+		'(mcp-authorize "server" "code")',
+		'Finish OAuth for a server: exchange the authorization `code` from its login link for tokens (saved for reuse). Then (load-mcp "server") connects directly.',
+		z.tuple([zList]),
+		([rest]) => {
+			const args = listToArray(rest);
+			const name = typeof args[0] === "string" ? args[0] : asName(args[0]);
+			const code = args[1];
+			if (typeof code !== "string")
+				throw new EvalException(
+					"mcp-authorize requires an authorization code string",
+					code ?? null,
+					false,
+				);
+			const conf = predefined.get(name);
+			if (!conf || !("url" in conf))
+				throw new EvalException("unknown OAuth MCP server", name, false);
+			mcpRequest("authorize", { url: conf.url, code, scopes: conf.scopes });
+			return newLispKeyword("authorized");
+		},
 	);
 
 	// (list-mcps) -> ((name :loaded|:unloaded count) ...)

--- a/packages/interpreter/src/mcp.ts
+++ b/packages/interpreter/src/mcp.ts
@@ -679,6 +679,27 @@ export function registerMcp(interp: Interp): void {
 		},
 	);
 
+	// (login "server") -> auth URL | :logged-in. See devdocs/oauth.md.
+	interp.def(
+		"login",
+		-1,
+		'(login "server")',
+		'Log in to an OAuth MCP server: begin authorization and return the login URL to open (or :logged-in if already authenticated). After approving, (load-mcp "server") connects.',
+		z.tuple([zList]),
+		([rest]) => {
+			const args = listToArray(rest);
+			const name = typeof args[0] === "string" ? args[0] : asName(args[0]);
+			const conf = predefined.get(name);
+			if (!conf || !("url" in conf))
+				throw new EvalException("unknown OAuth MCP server", name, false);
+			const res = mcpRequest("login", {
+				url: conf.url,
+				scopes: conf.scopes,
+			}) as { authUrl: string | null };
+			return res.authUrl ?? newLispKeyword("logged-in");
+		},
+	);
+
 	// (logout "server") -> :logged-out. See devdocs/oauth.md.
 	interp.def(
 		"logout",

--- a/packages/interpreter/src/mcp.ts
+++ b/packages/interpreter/src/mcp.ts
@@ -24,6 +24,7 @@ import {
 	type List,
 	newLispKeyword,
 	newSym,
+	Secret,
 	Sym,
 	zList,
 } from "./lisp.ts";
@@ -309,6 +310,9 @@ function lispToJson(x: unknown): unknown {
 	if (isNumeric(x)) return x;
 	if (x instanceof LispKeyword) return x.name;
 	if (x instanceof Sym) return x.name;
+	// A secret reveals its real value only here, on the way out into an MCP
+	// request/config (tool args, :headers, :env) — never through `str`.
+	if (x instanceof Secret) return x.reveal();
 	if (x instanceof Cell) {
 		if (isAlist(x)) {
 			const obj: Record<string, unknown> = {};

--- a/packages/interpreter/src/repl.ts
+++ b/packages/interpreter/src/repl.ts
@@ -129,6 +129,9 @@ export class AgentRepl extends MemoryRepl {
 	// The host-supplied conversation snapshot, kept so a post-error `reset()`
 	// can re-inject the globals until the next refresh.
 	private readonly conversationVars = new Map<string, unknown>();
+	// Host-supplied secrets, kept so a post-error `reset()` can re-inject them
+	// into the fresh interp's registry.
+	private readonly secrets = new Map<string, string>();
 
 	// Re-establish the halt built-in and the conversation globals on every fresh
 	// interp. Guards `conversationVars` because the base constructor calls this
@@ -137,6 +140,10 @@ export class AgentRepl extends MemoryRepl {
 		this.installHalt(interp);
 		const vars = this.conversationVars;
 		if (vars) for (const [name, value] of vars) defineVar(interp, name, value);
+		// Re-inject host secrets. Guarded because the base constructor calls
+		// setup() before this subclass's field initializers have run.
+		const secrets = this.secrets;
+		if (secrets?.size) interp.setSecrets(Object.fromEntries(secrets));
 	}
 
 	// Install `(halt [value])`: record that the program asked to stop and return
@@ -165,6 +172,24 @@ export class AgentRepl extends MemoryRepl {
 			this.conversationVars.set(name, value);
 			defineVar(this.interp, name, value);
 		}
+	}
+
+	// Register host-supplied secrets. Keys become listable by the agent via
+	// `(secrets)`; values stay opaque and are only usable inside calls (e.g. as
+	// MCP `:headers`). Merges into the registry; kept so `reset()` re-injects
+	// them. Env `LISPTC_SECRET_*` secrets are seeded by the interp itself.
+	setSecrets(record: Record<string, string>): void {
+		for (const [key, value] of Object.entries(record))
+			this.secrets.set(key, value);
+		this.interp.setSecrets(record);
+	}
+
+	// Load secrets from a `.env`-style file (KEY=VALUE lines) into the registry.
+	// Entries are kept so a post-error `reset()` re-injects them.
+	loadSecretsFromFile(path: string): void {
+		const record = this.interp.loadSecretsFromFile(path);
+		for (const [key, value] of Object.entries(record))
+			this.secrets.set(key, value);
 	}
 
 	// Whether the last-evaluated program called `(halt)`; reads and clears the

--- a/packages/interpreter/src/repl.ts
+++ b/packages/interpreter/src/repl.ts
@@ -23,6 +23,7 @@ import {
 	newSym,
 	prelude,
 	run,
+	type SecretSpec,
 	setWriter,
 	str,
 } from "./lisp.ts";
@@ -150,7 +151,7 @@ export class AgentRepl extends MemoryRepl {
 	private readonly conversationVars = new Map<string, unknown>();
 	// Host-supplied secrets, kept so a post-error `reset()` can re-inject them
 	// into the fresh interp's registry.
-	private readonly secrets = new Map<string, string>();
+	private readonly secrets = new Map<string, SecretSpec>();
 
 	// Re-establish the halt built-in and the conversation globals on every fresh
 	// interp. Guards `conversationVars` because the base constructor calls this
@@ -196,13 +197,14 @@ export class AgentRepl extends MemoryRepl {
 		}
 	}
 
-	// Register host-supplied secrets. Keys become listable by the agent via
-	// `(secrets)`; values stay opaque and are only usable inside calls (e.g. as
-	// MCP `:headers`). Merges into the registry; kept so `reset()` re-injects
-	// them. Env `LISPTC_SECRET_*` secrets are seeded by the interp itself.
-	setSecrets(record: Record<string, string>): void {
-		for (const [key, value] of Object.entries(record))
-			this.secrets.set(key, value);
+	// Register host-supplied secrets. Keys (and descriptions) become listable by
+	// the agent via `(secrets)`; values stay opaque and are only usable inside
+	// calls (e.g. as MCP `:headers`). Each spec is a bare value or
+	// `{ value, description }`. Merges into the registry; kept so `reset()`
+	// re-injects them. `REPL_*` env secrets are seeded by the interp itself.
+	setSecrets(record: Record<string, SecretSpec>): void {
+		for (const [key, spec] of Object.entries(record))
+			this.secrets.set(key, spec);
 		this.interp.setSecrets(record);
 	}
 

--- a/packages/interpreter/src/repl.ts
+++ b/packages/interpreter/src/repl.ts
@@ -159,12 +159,11 @@ export class AgentRepl extends MemoryRepl {
 		this.installHalt(interp);
 		const vars = this.conversationVars;
 		if (vars) for (const [name, value] of vars) defineVar(interp, name, value);
-		// Seed secrets from a `.env` file (same behaviour as the standalone REPL),
-		// so an embedder like pi picks it up automatically.
-		seedSecretsFromEnvFile(interp);
-		// Re-inject explicitly-set host secrets last, so they win over the file.
-		// Guarded because the base constructor calls setup() before this
-		// subclass's field initializers have run.
+		// Note: unlike the standalone CLI, an embedded AgentRepl does NOT
+		// auto-load a `.env` file — a host embedding this REPL (e.g. the pi
+		// extension) supplies secrets explicitly via setSecrets/loadSecretsFromFile.
+		// Re-inject explicitly-set host secrets. Guarded because the base
+		// constructor calls setup() before this subclass's field initializers run.
 		const secrets = this.secrets;
 		if (secrets?.size) interp.setSecrets(Object.fromEntries(secrets));
 	}

--- a/packages/interpreter/src/repl.ts
+++ b/packages/interpreter/src/repl.ts
@@ -27,6 +27,25 @@ import {
 	str,
 } from "./lisp.ts";
 
+// Seed an interp's secret registry from a `.env` file: the path in
+// $LISPTC_SECRETS_FILE, or `.env` in the working directory if it exists. Shared
+// by every REPL front-end (the CLI and the embeddable AgentRepl) so a `.env`
+// works the same everywhere. (REPL_* env vars are seeded by the Interp
+// constructor regardless; the file-path var is deliberately not REPL_-prefixed
+// so it isn't itself picked up as a secret.) Returns the loaded entries.
+export function seedSecretsFromEnvFile(interp: Interp): Record<string, string> {
+	const explicit = process.env.LISPTC_SECRETS_FILE;
+	const path = explicit ?? ".env";
+	try {
+		return interp.loadSecretsFromFile(path);
+	} catch {
+		// A missing default `.env` is fine; only warn if one was named explicitly.
+		if (explicit)
+			console.error(`warning: could not read secrets file ${explicit}`);
+		return {};
+	}
+}
+
 // A REPL owns an interpreter and can be reset to a fresh one.
 export interface Repl {
 	readonly interp: Interp;
@@ -140,8 +159,12 @@ export class AgentRepl extends MemoryRepl {
 		this.installHalt(interp);
 		const vars = this.conversationVars;
 		if (vars) for (const [name, value] of vars) defineVar(interp, name, value);
-		// Re-inject host secrets. Guarded because the base constructor calls
-		// setup() before this subclass's field initializers have run.
+		// Seed secrets from a `.env` file (same behaviour as the standalone REPL),
+		// so an embedder like pi picks it up automatically.
+		seedSecretsFromEnvFile(interp);
+		// Re-inject explicitly-set host secrets last, so they win over the file.
+		// Guarded because the base constructor calls setup() before this
+		// subclass's field initializers have run.
 		const secrets = this.secrets;
 		if (secrets?.size) interp.setSecrets(Object.fromEntries(secrets));
 	}

--- a/packages/interpreter/src/repl.ts
+++ b/packages/interpreter/src/repl.ts
@@ -129,7 +129,9 @@ export class MemoryRepl implements InMemoryRepl {
 		} finally {
 			setWriter(prev);
 		}
-		return out;
+		// Redact secret values here, at the single output boundary, so secrets
+		// behave as ordinary strings during evaluation but are never shown.
+		return this.currentInterp.redactSecrets(out);
 	}
 
 	// Discard all definitions; start from a fresh prelude-loaded interp.

--- a/packages/interpreter/src/repl.ts
+++ b/packages/interpreter/src/repl.ts
@@ -14,6 +14,7 @@
  *   read-only conversation-state globals refreshed from the host each step.
  */
 
+import { replEnv } from "@repo/env/repl.ts";
 import {
 	Cell,
 	EndOfFile,
@@ -35,7 +36,7 @@ import {
 // constructor regardless; the file-path var is deliberately not REPL_-prefixed
 // so it isn't itself picked up as a secret.) Returns the loaded entries.
 export function seedSecretsFromEnvFile(interp: Interp): Record<string, string> {
-	const explicit = process.env.LISPTC_SECRETS_FILE;
+	const explicit = replEnv.LISPTC_SECRETS_FILE;
 	const path = explicit ?? ".env";
 	try {
 		return interp.loadSecretsFromFile(path);

--- a/packages/interpreter/src/repl.ts
+++ b/packages/interpreter/src/repl.ts
@@ -129,9 +129,7 @@ export class MemoryRepl implements InMemoryRepl {
 		} finally {
 			setWriter(prev);
 		}
-		// Redact secret values here, at the single output boundary, so secrets
-		// behave as ordinary strings during evaluation but are never shown.
-		return this.currentInterp.redactSecrets(out);
+		return out;
 	}
 
 	// Discard all definitions; start from a fresh prelude-loaded interp.

--- a/packages/interpreter/src/source.ts
+++ b/packages/interpreter/src/source.ts
@@ -11,6 +11,7 @@ const FILES = [
 	"grammar.ts",
 	"mcp.ts",
 	"mcp-broker.ts",
+	"mcp-oauth.ts",
 	"lisptc.gbnf",
 ] as const;
 

--- a/packages/interpreter/test/mcp-oauth.test.ts
+++ b/packages/interpreter/test/mcp-oauth.test.ts
@@ -218,31 +218,26 @@ describe("CallbackServer (ingress)", () => {
 });
 
 describe("createAuthCallback", () => {
-	it("binds 0.0.0.0 and advertises the ingress URL when configured", async () => {
-		const prev = process.env.LISPTC_OAUTH_REDIRECT_URL;
-		process.env.LISPTC_OAUTH_REDIRECT_URL =
-			"https://mcp.example.com/oauth/callback";
+	it("binds 0.0.0.0 and advertises a given ingress URL", async () => {
+		const cb = await createAuthCallback(
+			8919,
+			"https://mcp.example.com/oauth/callback",
+		);
 		try {
-			const cb = await createAuthCallback(8919);
 			expect(cb).toBeInstanceOf(CallbackServer);
 			expect(cb.redirectUrl()).toBe("https://mcp.example.com/oauth/callback");
-			await cb.close();
 		} finally {
-			if (prev === undefined) delete process.env.LISPTC_OAUTH_REDIRECT_URL;
-			else process.env.LISPTC_OAUTH_REDIRECT_URL = prev;
+			await cb.close();
 		}
 	});
 
-	it("binds a local loopback server when no ingress URL is set", async () => {
-		const prev = process.env.LISPTC_OAUTH_REDIRECT_URL;
-		delete process.env.LISPTC_OAUTH_REDIRECT_URL;
+	it("binds a local loopback server when no ingress URL is given", async () => {
+		const cb = await createAuthCallback(8920);
 		try {
-			const cb = await createAuthCallback(8920);
 			expect(cb).toBeInstanceOf(CallbackServer);
 			expect(cb.redirectUrl()).toBe("http://127.0.0.1:8920/callback");
-			await cb.close();
 		} finally {
-			if (prev !== undefined) process.env.LISPTC_OAUTH_REDIRECT_URL = prev;
+			await cb.close();
 		}
 	});
 });

--- a/packages/interpreter/test/mcp-oauth.test.ts
+++ b/packages/interpreter/test/mcp-oauth.test.ts
@@ -176,6 +176,18 @@ describe("AuthCallback (loopback)", () => {
 		}
 	});
 
+	it("binds a fixed port and rejects a second bind on it", async () => {
+		const first = await LoopbackAuthCallback.start("/callback", 8917);
+		try {
+			expect(first.redirectUrl()).toBe("http://127.0.0.1:8917/callback");
+			await expect(
+				LoopbackAuthCallback.start("/callback", 8917),
+			).rejects.toMatchObject({ code: "EADDRINUSE" });
+		} finally {
+			await first.close();
+		}
+	});
+
 	it("times out if the code never arrives", async () => {
 		const cb = await LoopbackAuthCallback.start();
 		try {

--- a/packages/interpreter/test/mcp-oauth.test.ts
+++ b/packages/interpreter/test/mcp-oauth.test.ts
@@ -160,15 +160,78 @@ describe("CallbackServer (loopback)", () => {
 		}
 	});
 
-	it("rejects on a state mismatch", async () => {
+	it("ignores a callback for an unknown state without disturbing a pending flow", async () => {
 		const cb = await CallbackServer.start({ host: "127.0.0.1" });
 		try {
-			// Attach the rejection handler before triggering the callback.
-			const assertion = expect(cb.waitForCode("expected")).rejects.toThrow(
-				/state mismatch/,
+			const waiting = cb.waitForCode("expected", 200);
+			// A stray callback for a different state must not resolve/reject ours.
+			const res = await fetch(`${cb.redirectUrl()}?code=x&state=wrong`);
+			expect(res.status).toBe(400);
+			expect(await res.text()).toMatch(/unknown or has expired/);
+			// The right callback still completes the pending flow.
+			await fetch(`${cb.redirectUrl()}?code=the-code&state=expected`);
+			expect(await waiting).toBe("the-code");
+		} finally {
+			await cb.close();
+		}
+	});
+
+	it("routes concurrent flows to their own state", async () => {
+		const cb = await CallbackServer.start({ host: "127.0.0.1" });
+		try {
+			const a = cb.waitForCode("aaa");
+			const b = cb.waitForCode("bbb");
+			await fetch(`${cb.redirectUrl()}?code=code-b&state=bbb`);
+			await fetch(`${cb.redirectUrl()}?code=code-a&state=aaa`);
+			expect(await a).toBe("code-a");
+			expect(await b).toBe("code-b");
+		} finally {
+			await cb.close();
+		}
+	});
+
+	it("reflects the exchange outcome in the browser page and the wait", async () => {
+		const cb = await CallbackServer.start({ host: "127.0.0.1" });
+		try {
+			// A failing exchange yields an error page and a rejected wait, never a
+			// misleading "complete" page.
+			const failing = expect(
+				cb.waitForCode("bad", undefined, async () => {
+					throw new Error("PKCE mismatch");
+				}),
+			).rejects.toThrow(/PKCE mismatch/);
+			const res = await fetch(`${cb.redirectUrl()}?code=c&state=bad`);
+			expect(res.status).toBe(400);
+			expect(await res.text()).toMatch(/PKCE mismatch/);
+			await failing;
+
+			// A succeeding exchange runs before the success page is shown.
+			let exchanged = "";
+			const ok = cb.waitForCode("good", undefined, async (code) => {
+				exchanged = code;
+			});
+			const okRes = await fetch(`${cb.redirectUrl()}?code=c2&state=good`);
+			expect(okRes.status).toBe(200);
+			expect(await okRes.text()).toMatch(/Authorization complete/);
+			expect(await ok).toBe("c2");
+			expect(exchanged).toBe("c2");
+		} finally {
+			await cb.close();
+		}
+	});
+
+	it("surfaces an OAuth error redirect instead of hanging", async () => {
+		const cb = await CallbackServer.start({ host: "127.0.0.1" });
+		try {
+			const waiting = expect(cb.waitForCode("st")).rejects.toThrow(
+				/access_denied/,
 			);
-			await fetch(`${cb.redirectUrl()}?code=x&state=wrong`);
-			await assertion;
+			const res = await fetch(
+				`${cb.redirectUrl()}?error=access_denied&state=st`,
+			);
+			expect(res.status).toBe(400);
+			expect(await res.text()).toMatch(/access_denied/);
+			await waiting;
 		} finally {
 			await cb.close();
 		}

--- a/packages/interpreter/test/mcp-oauth.test.ts
+++ b/packages/interpreter/test/mcp-oauth.test.ts
@@ -1,0 +1,145 @@
+import { mkdtempSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { describe, expect, it } from "vitest";
+import {
+	FileOAuthStore,
+	type OAuthRecord,
+	type OAuthStore,
+	StoredOAuthProvider,
+} from "../src/mcp-oauth.ts";
+
+const REDIRECT = "http://127.0.0.1:8991/callback";
+
+function tmpDir(): string {
+	return mkdtempSync(join(tmpdir(), "lisptc-oauth-"));
+}
+
+describe("FileOAuthStore", () => {
+	it("round-trips a record and clears it", async () => {
+		const store = new FileOAuthStore(tmpDir());
+		expect(await store.load("https://mcp.example.com")).toBeUndefined();
+
+		const rec: OAuthRecord = {
+			tokens: { access_token: "at", token_type: "Bearer", refresh_token: "rt" },
+			codeVerifier: "v",
+		};
+		await store.save("https://mcp.example.com", rec);
+		expect(await store.load("https://mcp.example.com")).toEqual(rec);
+
+		await store.clear("https://mcp.example.com");
+		expect(await store.load("https://mcp.example.com")).toBeUndefined();
+	});
+
+	it("writes token files with owner-only permissions", async () => {
+		const dir = tmpDir();
+		const store = new FileOAuthStore(dir);
+		await store.save("https://mcp.example.com", {
+			tokens: { access_token: "at", token_type: "Bearer" },
+		});
+		// One 0600 file was created under the store dir.
+		const { readdirSync } = await import("node:fs");
+		const files = readdirSync(dir);
+		expect(files).toHaveLength(1);
+		expect(statSync(join(dir, files[0])).mode & 0o777).toBe(0o600);
+	});
+});
+
+describe("StoredOAuthProvider", () => {
+	// An in-memory OAuthStore, proving the interface is the seam a DB store would
+	// implement.
+	function memoryStore(): OAuthStore & { data: Map<string, OAuthRecord> } {
+		const data = new Map<string, OAuthRecord>();
+		return {
+			data,
+			async load(k) {
+				return data.get(k);
+			},
+			async save(k, r) {
+				data.set(k, structuredClone(r));
+			},
+			async clear(k) {
+				data.delete(k);
+			},
+		};
+	}
+
+	it("hydrates existing tokens so a later session reuses them", async () => {
+		const store = memoryStore();
+		store.data.set("https://mcp.example.com", {
+			tokens: { access_token: "cached", token_type: "Bearer" },
+		});
+		const p = await StoredOAuthProvider.create(
+			store,
+			"https://mcp.example.com/mcp",
+			REDIRECT,
+		);
+		expect(p.tokens()?.access_token).toBe("cached");
+		// Keyed by origin, so the /mcp path does not matter.
+		expect(p.redirectUrl).toBe(REDIRECT);
+		expect(p.clientMetadata.redirect_uris).toEqual([REDIRECT]);
+	});
+
+	it("write-throughs tokens, client info and verifier to the store", async () => {
+		const store = memoryStore();
+		const p = await StoredOAuthProvider.create(
+			store,
+			"https://mcp.example.com/mcp",
+			REDIRECT,
+		);
+		await p.saveClientInformation({
+			client_id: "cid",
+			redirect_uris: [REDIRECT],
+		});
+		await p.saveCodeVerifier("verifier-123");
+		await p.saveTokens({
+			access_token: "at",
+			token_type: "Bearer",
+			refresh_token: "rt",
+		});
+
+		const rec = store.data.get("https://mcp.example.com");
+		expect(rec?.clientInformation?.client_id).toBe("cid");
+		expect(rec?.codeVerifier).toBe("verifier-123");
+		expect(rec?.tokens?.refresh_token).toBe("rt");
+		expect(p.codeVerifier()).toBe("verifier-123");
+	});
+
+	it("captures the authorization URL instead of opening it", async () => {
+		const p = await StoredOAuthProvider.create(
+			memoryStore(),
+			"https://mcp.example.com/mcp",
+			REDIRECT,
+		);
+		expect(p.authorizationUrl).toBeUndefined();
+		const url = new URL("https://auth.example.com/authorize?client_id=cid");
+		p.redirectToAuthorization(url);
+		expect(p.authorizationUrl?.href).toBe(url.href);
+	});
+
+	it("throws if a code verifier is requested before one is saved", async () => {
+		const p = await StoredOAuthProvider.create(
+			memoryStore(),
+			"https://mcp.example.com/mcp",
+			REDIRECT,
+		);
+		expect(() => p.codeVerifier()).toThrow(/code verifier/);
+	});
+
+	it("invalidateCredentials clears the selected scope", async () => {
+		const store = memoryStore();
+		const p = await StoredOAuthProvider.create(
+			store,
+			"https://mcp.example.com/mcp",
+			REDIRECT,
+		);
+		await p.saveTokens({ access_token: "at", token_type: "Bearer" });
+		await p.saveClientInformation({
+			client_id: "cid",
+			redirect_uris: [REDIRECT],
+		});
+		await p.invalidateCredentials("tokens");
+		expect(p.tokens()).toBeUndefined();
+		expect(p.clientInformation()?.client_id).toBe("cid"); // client kept
+	});
+});

--- a/packages/interpreter/test/mcp-oauth.test.ts
+++ b/packages/interpreter/test/mcp-oauth.test.ts
@@ -3,7 +3,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+	createAuthCallback,
+	ExternalAuthCallback,
 	FileOAuthStore,
+	LoopbackAuthCallback,
 	type OAuthRecord,
 	type OAuthStore,
 	StoredOAuthProvider,
@@ -141,5 +144,87 @@ describe("StoredOAuthProvider", () => {
 		await p.invalidateCredentials("tokens");
 		expect(p.tokens()).toBeUndefined();
 		expect(p.clientInformation()?.client_id).toBe("cid"); // client kept
+	});
+});
+
+describe("AuthCallback (loopback)", () => {
+	it("captures the code from a same-machine redirect and returns it", async () => {
+		const cb = await LoopbackAuthCallback.start();
+		try {
+			const url = cb.redirectUrl();
+			expect(url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/callback$/);
+			const waiting = cb.waitForCode("st4te");
+			// Simulate the browser hitting the loopback redirect.
+			await fetch(`${url}?code=the-code&state=st4te`);
+			expect(await waiting).toBe("the-code");
+		} finally {
+			await cb.close();
+		}
+	});
+
+	it("rejects on a state mismatch", async () => {
+		const cb = await LoopbackAuthCallback.start();
+		try {
+			// Attach the rejection handler before triggering the callback.
+			const assertion = expect(cb.waitForCode("expected")).rejects.toThrow(
+				/state mismatch/,
+			);
+			await fetch(`${cb.redirectUrl()}?code=x&state=wrong`);
+			await assertion;
+		} finally {
+			await cb.close();
+		}
+	});
+
+	it("times out if the code never arrives", async () => {
+		const cb = await LoopbackAuthCallback.start();
+		try {
+			await expect(cb.waitForCode("s", 20)).rejects.toThrow(/timed out/);
+		} finally {
+			await cb.close();
+		}
+	});
+});
+
+describe("AuthCallback (external / ingress)", () => {
+	it("registers the configured public redirect and resolves via submitCode", async () => {
+		const cb = new ExternalAuthCallback(
+			"https://mcp.example.com/oauth/callback",
+		);
+		expect(cb.redirectUrl()).toBe("https://mcp.example.com/oauth/callback");
+		const waiting = cb.waitForCode("state-1");
+		// An ingress handler (or (mcp-authorize)) delivers the code out-of-band.
+		cb.submitCode({ code: "ingress-code", state: "state-1" });
+		expect(await waiting).toBe("ingress-code");
+	});
+});
+
+describe("createAuthCallback", () => {
+	it("uses the ingress redirect URL when LISPTC_OAUTH_REDIRECT_URL is set", async () => {
+		const prev = process.env.LISPTC_OAUTH_REDIRECT_URL;
+		process.env.LISPTC_OAUTH_REDIRECT_URL =
+			"https://mcp.example.com/oauth/callback";
+		try {
+			const cb = await createAuthCallback();
+			expect(cb).toBeInstanceOf(ExternalAuthCallback);
+			expect(cb.redirectUrl()).toBe("https://mcp.example.com/oauth/callback");
+			await cb.close();
+		} finally {
+			if (prev === undefined) delete process.env.LISPTC_OAUTH_REDIRECT_URL;
+			else process.env.LISPTC_OAUTH_REDIRECT_URL = prev;
+		}
+	});
+
+	it("falls back to a loopback server for local use", async () => {
+		const prev = process.env.LISPTC_OAUTH_REDIRECT_URL;
+		delete process.env.LISPTC_OAUTH_REDIRECT_URL;
+		try {
+			const cb = await createAuthCallback();
+			expect(cb).toBeInstanceOf(LoopbackAuthCallback);
+			expect(cb.redirectUrl()).toMatch(/^http:\/\/127\.0\.0\.1:\d+/);
+			await cb.close();
+		} finally {
+			if (prev !== undefined) process.env.LISPTC_OAUTH_REDIRECT_URL = prev;
+		}
 	});
 });

--- a/packages/interpreter/test/mcp-oauth.test.ts
+++ b/packages/interpreter/test/mcp-oauth.test.ts
@@ -3,10 +3,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
+	CallbackServer,
 	createAuthCallback,
-	ExternalAuthCallback,
 	FileOAuthStore,
-	LoopbackAuthCallback,
 	type OAuthRecord,
 	type OAuthStore,
 	StoredOAuthProvider,
@@ -147,14 +146,13 @@ describe("StoredOAuthProvider", () => {
 	});
 });
 
-describe("AuthCallback (loopback)", () => {
+describe("CallbackServer (loopback)", () => {
 	it("captures the code from a same-machine redirect and returns it", async () => {
-		const cb = await LoopbackAuthCallback.start();
+		const cb = await CallbackServer.start({ host: "127.0.0.1" });
 		try {
 			const url = cb.redirectUrl();
 			expect(url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/callback$/);
 			const waiting = cb.waitForCode("st4te");
-			// Simulate the browser hitting the loopback redirect.
 			await fetch(`${url}?code=the-code&state=st4te`);
 			expect(await waiting).toBe("the-code");
 		} finally {
@@ -163,7 +161,7 @@ describe("AuthCallback (loopback)", () => {
 	});
 
 	it("rejects on a state mismatch", async () => {
-		const cb = await LoopbackAuthCallback.start();
+		const cb = await CallbackServer.start({ host: "127.0.0.1" });
 		try {
 			// Attach the rejection handler before triggering the callback.
 			const assertion = expect(cb.waitForCode("expected")).rejects.toThrow(
@@ -177,11 +175,11 @@ describe("AuthCallback (loopback)", () => {
 	});
 
 	it("binds a fixed port and rejects a second bind on it", async () => {
-		const first = await LoopbackAuthCallback.start("/callback", 8917);
+		const first = await CallbackServer.start({ host: "127.0.0.1", port: 8917 });
 		try {
 			expect(first.redirectUrl()).toBe("http://127.0.0.1:8917/callback");
 			await expect(
-				LoopbackAuthCallback.start("/callback", 8917),
+				CallbackServer.start({ host: "127.0.0.1", port: 8917 }),
 			).rejects.toMatchObject({ code: "EADDRINUSE" });
 		} finally {
 			await first.close();
@@ -189,7 +187,7 @@ describe("AuthCallback (loopback)", () => {
 	});
 
 	it("times out if the code never arrives", async () => {
-		const cb = await LoopbackAuthCallback.start();
+		const cb = await CallbackServer.start({ host: "127.0.0.1" });
 		try {
 			await expect(cb.waitForCode("s", 20)).rejects.toThrow(/timed out/);
 		} finally {
@@ -198,27 +196,35 @@ describe("AuthCallback (loopback)", () => {
 	});
 });
 
-describe("AuthCallback (external / ingress)", () => {
-	it("registers the configured public redirect and resolves via submitCode", async () => {
-		const cb = new ExternalAuthCallback(
-			"https://mcp.example.com/oauth/callback",
-		);
-		expect(cb.redirectUrl()).toBe("https://mcp.example.com/oauth/callback");
-		const waiting = cb.waitForCode("state-1");
-		// An ingress handler (or (mcp-authorize)) delivers the code out-of-band.
-		cb.submitCode({ code: "ingress-code", state: "state-1" });
-		expect(await waiting).toBe("ingress-code");
+describe("CallbackServer (ingress)", () => {
+	it("binds 0.0.0.0, advertises the public URL, and captures via that path", async () => {
+		const cb = await CallbackServer.start({
+			host: "0.0.0.0",
+			port: 8918,
+			path: "/oauth/callback",
+			redirectUrl: "https://mcp.example.com/oauth/callback",
+		});
+		try {
+			// The auth server sees the public domain URL...
+			expect(cb.redirectUrl()).toBe("https://mcp.example.com/oauth/callback");
+			// ...while the ingress reaches the pod on 0.0.0.0:port at the same path.
+			const waiting = cb.waitForCode("s");
+			await fetch(`http://127.0.0.1:8918/oauth/callback?code=ingress&state=s`);
+			expect(await waiting).toBe("ingress");
+		} finally {
+			await cb.close();
+		}
 	});
 });
 
 describe("createAuthCallback", () => {
-	it("uses the ingress redirect URL when LISPTC_OAUTH_REDIRECT_URL is set", async () => {
+	it("binds 0.0.0.0 and advertises the ingress URL when configured", async () => {
 		const prev = process.env.LISPTC_OAUTH_REDIRECT_URL;
 		process.env.LISPTC_OAUTH_REDIRECT_URL =
 			"https://mcp.example.com/oauth/callback";
 		try {
-			const cb = await createAuthCallback();
-			expect(cb).toBeInstanceOf(ExternalAuthCallback);
+			const cb = await createAuthCallback(8919);
+			expect(cb).toBeInstanceOf(CallbackServer);
 			expect(cb.redirectUrl()).toBe("https://mcp.example.com/oauth/callback");
 			await cb.close();
 		} finally {
@@ -227,13 +233,13 @@ describe("createAuthCallback", () => {
 		}
 	});
 
-	it("falls back to a loopback server for local use", async () => {
+	it("binds a local loopback server when no ingress URL is set", async () => {
 		const prev = process.env.LISPTC_OAUTH_REDIRECT_URL;
 		delete process.env.LISPTC_OAUTH_REDIRECT_URL;
 		try {
-			const cb = await createAuthCallback();
-			expect(cb).toBeInstanceOf(LoopbackAuthCallback);
-			expect(cb.redirectUrl()).toMatch(/^http:\/\/127\.0\.0\.1:\d+/);
+			const cb = await createAuthCallback(8920);
+			expect(cb).toBeInstanceOf(CallbackServer);
+			expect(cb.redirectUrl()).toBe("http://127.0.0.1:8920/callback");
 			await cb.close();
 		} finally {
 			if (prev !== undefined) process.env.LISPTC_OAUTH_REDIRECT_URL = prev;

--- a/packages/interpreter/test/oauth-logout.test.ts
+++ b/packages/interpreter/test/oauth-logout.test.ts
@@ -35,3 +35,27 @@ describe("logout", () => {
 		expect(() => run(interp, '(logout "nope")')).toThrow(/unknown/);
 	});
 });
+
+describe("login", () => {
+	const interp = new Interp();
+	run(interp, prelude);
+
+	afterAll(() => {
+		run(interp, "(mcp-shutdown)");
+	});
+
+	it("returns :logged-in when a token is already stored", () => {
+		// A stored token means no network / no authorization is needed.
+		const file = join(dir, "https___mcp.linear.app.json");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(
+			file,
+			JSON.stringify({ tokens: { access_token: "x", token_type: "Bearer" } }),
+		);
+		expect(str(run(interp, '(login "linear")'))).toBe(":logged-in");
+	});
+
+	it("errors for an unknown server", () => {
+		expect(() => run(interp, '(login "nope")')).toThrow(/unknown/);
+	});
+});

--- a/packages/interpreter/test/oauth-logout.test.ts
+++ b/packages/interpreter/test/oauth-logout.test.ts
@@ -1,0 +1,37 @@
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, it } from "vitest";
+import { Interp, prelude, run, str } from "../src/lisp.ts";
+
+// Point the broker's file store at a temp dir before it starts (the worker
+// inherits process.env when spawned on the first MCP call).
+const dir = mkdtempSync(join(tmpdir(), "lisptc-logout-"));
+process.env.LISPTC_OAUTH_DIR = dir;
+
+describe("logout", () => {
+	const interp = new Interp();
+	run(interp, prelude);
+
+	afterAll(() => {
+		run(interp, "(mcp-shutdown)");
+	});
+
+	it("deletes a server's saved OAuth session via the store", () => {
+		// The file the FileOAuthStore uses for the posthog origin.
+		const file = join(dir, "https___mcp.posthog.com.json");
+		mkdirSync(dir, { recursive: true });
+		writeFileSync(
+			file,
+			JSON.stringify({ tokens: { access_token: "x", token_type: "Bearer" } }),
+		);
+		expect(existsSync(file)).toBe(true);
+
+		expect(str(run(interp, '(logout "posthog")'))).toBe(":logged-out");
+		expect(existsSync(file)).toBe(false);
+	});
+
+	it("errors for an unknown server", () => {
+		expect(() => run(interp, '(logout "nope")')).toThrow(/unknown/);
+	});
+});

--- a/packages/interpreter/test/secrets.test.ts
+++ b/packages/interpreter/test/secrets.test.ts
@@ -56,6 +56,21 @@ describe("secret registry", () => {
 	});
 });
 
+describe("secret registry (composition via concat)", () => {
+	it("concat of plain strings still returns a plain string", () => {
+		expect(ev('(concat "Bearer " "abc")')).toBe('"Bearer abc"');
+	});
+
+	it("concat with a secret yields an opaque, redacted secret", () => {
+		const interp = freshInterp();
+		interp.setSecrets({ FOO: "s3cr3t" });
+		// Building `Bearer <key>` must not throw and must stay redacted.
+		const out = ev('(concat "Bearer " (secret "FOO"))', interp);
+		expect(out).toBe("#<secret:FOO>");
+		expect(out).not.toContain("s3cr3t");
+	});
+});
+
 describe("secret registry (env seeding)", () => {
 	it("seeds secrets from REPL_* env vars, overridable by setSecrets", () => {
 		const prev = process.env.REPL_FOO;
@@ -146,6 +161,10 @@ describe("secret registry (reveal at the MCP call boundary)", () => {
 		expect(str(run(interp, '(fx/echo :message (secret "FOO"))'))).toBe(
 			'"s3cr3t"',
 		);
+		// A composed secret (e.g. `Bearer <key>`) also reveals its full value.
+		expect(
+			str(run(interp, '(fx/echo :message (concat "Bearer " (secret "FOO")))')),
+		).toBe('"Bearer s3cr3t"');
 		// But the secret itself still prints redacted.
 		expect(str(run(interp, '(secret "FOO")'))).toBe("#<secret:FOO>");
 	});

--- a/packages/interpreter/test/secrets.test.ts
+++ b/packages/interpreter/test/secrets.test.ts
@@ -1,0 +1,137 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { afterAll, describe, expect, it } from "vitest";
+import { Interp, prelude, run, setWriter, str } from "../src/lisp.ts";
+import { AgentRepl } from "../src/repl.ts";
+import { ev, freshInterp } from "./helpers.ts";
+
+const FIXTURE = fileURLToPath(
+	new URL("./fixture-mcp-server.ts", import.meta.url),
+);
+
+describe("secret registry", () => {
+	it("lists the keys of registered secrets", () => {
+		const interp = freshInterp();
+		interp.setSecrets({ FOO: "bar", BAZ: "qux" });
+		const out = ev("(secrets)", interp);
+		expect(out).toContain("FOO");
+		expect(out).toContain("BAZ");
+	});
+
+	it("returns an empty list when no secrets are registered", () => {
+		expect(ev("(secrets)")).toBe("nil");
+	});
+
+	it("errors when reading an unknown secret", () => {
+		expect(() => ev('(secret "NOPE")')).toThrow(/unknown secret/);
+	});
+
+	it("redacts a secret value when printed or returned", () => {
+		const interp = freshInterp();
+		interp.setSecrets({ FOO: "s3cr3t" });
+		// Returned value is opaque.
+		expect(ev('(secret "FOO")', interp)).toBe("#<secret:FOO>");
+		// Printed value is opaque too, and never leaks the raw value.
+		let output = "";
+		const prev = setWriter((s: string) => {
+			output += s;
+		});
+		try {
+			run(interp, '(princ (secret "FOO"))');
+		} finally {
+			setWriter(prev);
+		}
+		expect(output).toBe("#<secret:FOO>");
+		expect(output).not.toContain("s3cr3t");
+	});
+
+	it("does not leak the value even nested inside a printed list", () => {
+		const interp = freshInterp();
+		interp.setSecrets({ FOO: "s3cr3t" });
+		const out = ev('(list "a" (secret "FOO") "b")', interp);
+		expect(out).toBe('("a" #<secret:FOO> "b")');
+		expect(out).not.toContain("s3cr3t");
+	});
+});
+
+describe("secret registry (env seeding)", () => {
+	it("seeds secrets from LISPTC_SECRET_* env vars, overridable by setSecrets", () => {
+		const prev = process.env.LISPTC_SECRET_FOO;
+		process.env.LISPTC_SECRET_FOO = "from-env";
+		try {
+			const interp = new Interp();
+			run(interp, prelude);
+			expect(str(run(interp, "(secrets)"))).toContain("FOO");
+			// The real value is revealed only on the way into a call; env-seeded
+			// secrets print redacted like any other.
+			expect(str(run(interp, '(secret "FOO")'))).toBe("#<secret:FOO>");
+			// Programmatic setSecrets overrides the env-seeded value.
+			interp.setSecrets({ FOO: "from-host" });
+			expect(str(run(interp, '(secret "FOO")'))).toBe("#<secret:FOO>");
+		} finally {
+			if (prev === undefined) delete process.env.LISPTC_SECRET_FOO;
+			else process.env.LISPTC_SECRET_FOO = prev;
+		}
+	});
+});
+
+describe("secret registry (.env file loading)", () => {
+	function writeEnvFile(contents: string): string {
+		const dir = mkdtempSync(join(tmpdir(), "lisptc-secrets-"));
+		const path = join(dir, ".env");
+		writeFileSync(path, contents);
+		return path;
+	}
+
+	it("loads KEY=VALUE entries from a .env file as secrets", () => {
+		const path = writeEnvFile(
+			'# a comment\nLINEAR_API_KEY=lin_abc123\nQUOTED="with spaces"\n',
+		);
+		const interp = freshInterp();
+		interp.loadSecretsFromFile(path);
+		const keys = ev("(secrets)", interp);
+		expect(keys).toContain("LINEAR_API_KEY");
+		expect(keys).toContain("QUOTED");
+		// Values stay redacted.
+		expect(ev('(secret "LINEAR_API_KEY")', interp)).toBe(
+			"#<secret:LINEAR_API_KEY>",
+		);
+	});
+
+	it("re-injects file-loaded secrets on AgentRepl reset()", () => {
+		const path = writeEnvFile("FOO=bar\n");
+		const repl = new AgentRepl();
+		repl.loadSecretsFromFile(path);
+		expect(repl.eval("(secrets)")).toContain("FOO");
+		repl.reset();
+		expect(repl.eval("(secrets)")).toContain("FOO");
+	});
+});
+
+describe("secret registry (reveal at the MCP call boundary)", () => {
+	const interp = new Interp();
+	run(interp, prelude);
+	interp.setSecrets({ FOO: "s3cr3t" });
+
+	afterAll(() => {
+		run(interp, "(mcp-shutdown)");
+	});
+
+	it("passes the real value into an MCP tool call while staying redacted in the REPL", () => {
+		str(
+			run(
+				interp,
+				`(await (load-mcp :name "fx" :command "node" :args (quote ("--experimental-transform-types" "${FIXTURE}"))))`,
+			),
+		);
+		// The echo fixture returns its :message argument verbatim, proving the
+		// secret was revealed on the way into the call.
+		expect(str(run(interp, '(fx/echo :message (secret "FOO"))'))).toBe(
+			'"s3cr3t"',
+		);
+		// But the secret itself still prints redacted.
+		expect(str(run(interp, '(secret "FOO")'))).toBe("#<secret:FOO>");
+	});
+});

--- a/packages/interpreter/test/secrets.test.ts
+++ b/packages/interpreter/test/secrets.test.ts
@@ -108,6 +108,21 @@ describe("secret registry (.env file loading)", () => {
 		repl.reset();
 		expect(repl.eval("(secrets)")).toContain("FOO");
 	});
+
+	it("auto-loads $LISPTC_SECRETS_FILE for an embedder (e.g. pi via AgentRepl)", () => {
+		const path = writeEnvFile("PI_TOKEN=t0ken\n");
+		const prev = process.env.LISPTC_SECRETS_FILE;
+		process.env.LISPTC_SECRETS_FILE = path;
+		try {
+			// A plain AgentRepl (no explicit setSecrets) picks the file up.
+			const repl = new AgentRepl();
+			expect(repl.eval("(secrets)")).toContain("PI_TOKEN");
+			expect(repl.eval('(secret "PI_TOKEN")')).toContain("#<secret:PI_TOKEN>");
+		} finally {
+			if (prev === undefined) delete process.env.LISPTC_SECRETS_FILE;
+			else process.env.LISPTC_SECRETS_FILE = prev;
+		}
+	});
 });
 
 describe("secret registry (reveal at the MCP call boundary)", () => {

--- a/packages/interpreter/test/secrets.test.ts
+++ b/packages/interpreter/test/secrets.test.ts
@@ -3,7 +3,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { afterAll, describe, expect, it } from "vitest";
-import { Interp, prelude, run, setWriter, str } from "../src/lisp.ts";
+import { Interp, prelude, run, str } from "../src/lisp.ts";
 import { AgentRepl } from "../src/repl.ts";
 import { ev, freshInterp } from "./helpers.ts";
 
@@ -11,13 +11,26 @@ const FIXTURE = fileURLToPath(
 	new URL("./fixture-mcp-server.ts", import.meta.url),
 );
 
-describe("secret registry", () => {
-	it("lists the keys of registered secrets", () => {
+// Interpreter-level behaviour: secrets are ordinary strings; redaction is a
+// REPL concern (see the AgentRepl block below), so `ev` sees raw values.
+describe("secret registry (interpreter level)", () => {
+	it("lists the keys of registered secrets (prefix kept)", () => {
 		const interp = freshInterp();
-		interp.setSecrets({ FOO: "bar", BAZ: "qux" });
+		interp.setSecrets({ REPL_FOO: "bar", REPL_BAZ: "qux" });
 		const out = ev("(secrets)", interp);
-		expect(out).toContain("FOO");
-		expect(out).toContain("BAZ");
+		expect(out).toContain("REPL_FOO");
+		expect(out).toContain("REPL_BAZ");
+	});
+
+	it("only registers keys starting with REPL_", () => {
+		const interp = freshInterp();
+		interp.setSecrets({ REPL_FOO: "bar", NOT_A_SECRET: "nope" });
+		const out = ev("(secrets)", interp);
+		expect(out).toContain("REPL_FOO");
+		expect(out).not.toContain("NOT_A_SECRET");
+		expect(() => ev('(secret "NOT_A_SECRET")', interp)).toThrow(
+			/unknown secret/,
+		);
 	});
 
 	it("returns an empty list when no secrets are registered", () => {
@@ -25,66 +38,70 @@ describe("secret registry", () => {
 	});
 
 	it("errors when reading an unknown secret", () => {
-		expect(() => ev('(secret "NOPE")')).toThrow(/unknown secret/);
+		expect(() => ev('(secret "REPL_NOPE")')).toThrow(/unknown secret/);
 	});
 
-	it("redacts a secret value when printed or returned", () => {
+	it("is an ordinary string usable by any text function", () => {
 		const interp = freshInterp();
-		interp.setSecrets({ FOO: "s3cr3t" });
-		// Returned value is opaque.
-		expect(ev('(secret "FOO")', interp)).toBe("#<secret:FOO>");
-		// Printed value is opaque too, and never leaks the raw value.
-		let output = "";
-		const prev = setWriter((s: string) => {
-			output += s;
-		});
-		try {
-			run(interp, '(princ (secret "FOO"))');
-		} finally {
-			setWriter(prev);
-		}
-		expect(output).toBe("#<secret:FOO>");
-		expect(output).not.toContain("s3cr3t");
-	});
-
-	it("does not leak the value even nested inside a printed list", () => {
-		const interp = freshInterp();
-		interp.setSecrets({ FOO: "s3cr3t" });
-		const out = ev('(list "a" (secret "FOO") "b")', interp);
-		expect(out).toBe('("a" #<secret:FOO> "b")');
-		expect(out).not.toContain("s3cr3t");
+		interp.setSecrets({ REPL_FOO: "s3cr3t" });
+		// A raw secret is just its value at the interpreter level.
+		expect(ev('(secret "REPL_FOO")', interp)).toBe('"s3cr3t"');
+		// Every string function works — concat, upcase, length, ...
+		expect(ev('(concat "Bearer " (secret "REPL_FOO"))', interp)).toBe(
+			'"Bearer s3cr3t"',
+		);
+		expect(ev('(string-upcase (secret "REPL_FOO"))', interp)).toBe('"S3CR3T"');
+		expect(ev('(length (secret "REPL_FOO"))', interp)).toBe("6");
 	});
 });
 
-describe("secret registry (composition via concat)", () => {
-	it("concat of plain strings still returns a plain string", () => {
-		expect(ev('(concat "Bearer " "abc")')).toBe('"Bearer abc"');
+// The REPL redacts secret values out of everything it prints — returned
+// values and prin1/princ side-effect output alike.
+describe("secret registry (REPL redaction)", () => {
+	function replWithSecret(value: string): AgentRepl {
+		const repl = new AgentRepl();
+		repl.setSecrets({ REPL_FOO: value });
+		return repl;
+	}
+
+	it("redacts a returned secret value", () => {
+		const repl = replWithSecret("s3cr3t");
+		expect(repl.eval('(secret "REPL_FOO")').trim()).toBe(
+			'"#<secret:REPL_FOO>"',
+		);
 	});
 
-	it("concat with a secret yields an opaque, redacted secret", () => {
-		const interp = freshInterp();
-		interp.setSecrets({ FOO: "s3cr3t" });
-		// Building `Bearer <key>` must not throw and must stay redacted.
-		const out = ev('(concat "Bearer " (secret "FOO"))', interp);
-		expect(out).toBe("#<secret:FOO>");
+	it("redacts side-effect (princ) output", () => {
+		const repl = replWithSecret("s3cr3t");
+		const out = repl.eval('(princ (secret "REPL_FOO"))');
 		expect(out).not.toContain("s3cr3t");
+		expect(out).toContain("#<secret:REPL_FOO>");
+	});
+
+	it("redacts a secret nested inside a composed string", () => {
+		const repl = replWithSecret("s3cr3t");
+		const out = repl.eval('(concat "Bearer " (secret "REPL_FOO"))').trim();
+		// The `Bearer ` text stays; only the secret value is masked.
+		expect(out).toBe('"Bearer #<secret:REPL_FOO>"');
+		expect(out).not.toContain("s3cr3t");
+	});
+
+	it("does not redact when nothing matches a secret value", () => {
+		const repl = replWithSecret("s3cr3t");
+		expect(repl.eval('(concat "a" "b")').trim()).toBe('"ab"');
 	});
 });
 
 describe("secret registry (env seeding)", () => {
-	it("seeds secrets from REPL_* env vars, overridable by setSecrets", () => {
+	it("seeds secrets from REPL_* env vars, keeping the prefix", () => {
 		const prev = process.env.REPL_FOO;
 		process.env.REPL_FOO = "from-env";
 		try {
 			const interp = new Interp();
 			run(interp, prelude);
-			expect(str(run(interp, "(secrets)"))).toContain("FOO");
-			// The real value is revealed only on the way into a call; env-seeded
-			// secrets print redacted like any other.
-			expect(str(run(interp, '(secret "FOO")'))).toBe("#<secret:FOO>");
-			// Programmatic setSecrets overrides the env-seeded value.
-			interp.setSecrets({ FOO: "from-host" });
-			expect(str(run(interp, '(secret "FOO")'))).toBe("#<secret:FOO>");
+			expect(str(run(interp, "(secrets)"))).toContain("REPL_FOO");
+			interp.setSecrets({ REPL_FOO: "from-host" });
+			expect(str(run(interp, '(secret "REPL_FOO")'))).toBe('"from-host"');
 		} finally {
 			if (prev === undefined) delete process.env.REPL_FOO;
 			else process.env.REPL_FOO = prev;
@@ -100,39 +117,33 @@ describe("secret registry (.env file loading)", () => {
 		return path;
 	}
 
-	it("loads KEY=VALUE entries from a .env file as secrets", () => {
+	it("loads only REPL_-prefixed entries, keeping the prefix", () => {
 		const path = writeEnvFile(
-			'# a comment\nLINEAR_API_KEY=lin_abc123\nQUOTED="with spaces"\n',
+			"# a comment\nREPL_LINEAR_API_KEY=lin_abc123\nNOT_A_SECRET=nope\n",
 		);
 		const interp = freshInterp();
 		interp.loadSecretsFromFile(path);
 		const keys = ev("(secrets)", interp);
-		expect(keys).toContain("LINEAR_API_KEY");
-		expect(keys).toContain("QUOTED");
-		// Values stay redacted.
-		expect(ev('(secret "LINEAR_API_KEY")', interp)).toBe(
-			"#<secret:LINEAR_API_KEY>",
-		);
+		expect(keys).toContain("REPL_LINEAR_API_KEY");
+		expect(keys).not.toContain("NOT_A_SECRET");
 	});
 
 	it("re-injects explicitly-loaded secrets on AgentRepl reset()", () => {
-		const path = writeEnvFile("FOO=bar\n");
+		const path = writeEnvFile("REPL_FOO=bar\n");
 		const repl = new AgentRepl();
-		// An embedder must opt in explicitly; AgentRepl does not auto-load .env.
 		repl.loadSecretsFromFile(path);
-		expect(repl.eval("(secrets)")).toContain("FOO");
+		expect(repl.eval("(secrets)")).toContain("REPL_FOO");
 		repl.reset();
-		expect(repl.eval("(secrets)")).toContain("FOO");
+		expect(repl.eval("(secrets)")).toContain("REPL_FOO");
 	});
 
 	it("does not auto-load $LISPTC_SECRETS_FILE for an embedded AgentRepl", () => {
-		const path = writeEnvFile("PI_TOKEN=t0ken\n");
+		const path = writeEnvFile("REPL_PI_TOKEN=t0ken\n");
 		const prev = process.env.LISPTC_SECRETS_FILE;
 		process.env.LISPTC_SECRETS_FILE = path;
 		try {
-			// A plain AgentRepl (the pi embedding) must NOT pick the file up.
 			const repl = new AgentRepl();
-			expect(repl.eval("(secrets)")).not.toContain("PI_TOKEN");
+			expect(repl.eval("(secrets)")).not.toContain("REPL_PI_TOKEN");
 		} finally {
 			if (prev === undefined) delete process.env.LISPTC_SECRETS_FILE;
 			else process.env.LISPTC_SECRETS_FILE = prev;
@@ -140,16 +151,16 @@ describe("secret registry (.env file loading)", () => {
 	});
 });
 
-describe("secret registry (reveal at the MCP call boundary)", () => {
+describe("secret registry (used in an MCP call)", () => {
 	const interp = new Interp();
 	run(interp, prelude);
-	interp.setSecrets({ FOO: "s3cr3t" });
+	interp.setSecrets({ REPL_FOO: "s3cr3t" });
 
 	afterAll(() => {
 		run(interp, "(mcp-shutdown)");
 	});
 
-	it("passes the real value into an MCP tool call while staying redacted in the REPL", () => {
+	it("passes the real value (and composed values) into an MCP tool call", () => {
 		str(
 			run(
 				interp,
@@ -157,15 +168,17 @@ describe("secret registry (reveal at the MCP call boundary)", () => {
 			),
 		);
 		// The echo fixture returns its :message argument verbatim, proving the
-		// secret was revealed on the way into the call.
-		expect(str(run(interp, '(fx/echo :message (secret "FOO"))'))).toBe(
+		// real value (no redaction) reaches the tool.
+		expect(str(run(interp, '(fx/echo :message (secret "REPL_FOO"))'))).toBe(
 			'"s3cr3t"',
 		);
-		// A composed secret (e.g. `Bearer <key>`) also reveals its full value.
 		expect(
-			str(run(interp, '(fx/echo :message (concat "Bearer " (secret "FOO")))')),
+			str(
+				run(
+					interp,
+					'(fx/echo :message (concat "Bearer " (secret "REPL_FOO")))',
+				),
+			),
 		).toBe('"Bearer s3cr3t"');
-		// But the secret itself still prints redacted.
-		expect(str(run(interp, '(secret "FOO")'))).toBe("#<secret:FOO>");
 	});
 });

--- a/packages/interpreter/test/secrets.test.ts
+++ b/packages/interpreter/test/secrets.test.ts
@@ -12,12 +12,25 @@ const FIXTURE = fileURLToPath(
 );
 
 describe("secret registry", () => {
-	it("lists the keys of registered secrets (prefix kept)", () => {
+	it("lists (key . description) pairs for each secret", () => {
 		const interp = freshInterp();
-		interp.setSecrets({ REPL_FOO: "bar", REPL_BAZ: "qux" });
-		const out = ev("(secrets)", interp);
-		expect(out).toContain("REPL_FOO");
-		expect(out).toContain("REPL_BAZ");
+		interp.setSecrets({
+			REPL_API_KEY: { value: "lin_abc", description: "Linear API key" },
+			REPL_DB_PASS: "hunter2", // bare value => empty description
+		});
+		expect(ev("(secrets)", interp)).toBe(
+			'(("REPL_API_KEY" . "Linear API key") ("REPL_DB_PASS" . ""))',
+		);
+	});
+
+	it("reads a description out of the alist with assoc", () => {
+		const interp = freshInterp();
+		interp.setSecrets({
+			REPL_API_KEY: { value: "lin_abc", description: "Linear API key" },
+		});
+		expect(ev('(cdr (assoc "REPL_API_KEY" (secrets)))', interp)).toBe(
+			'"Linear API key"',
+		);
 	});
 
 	it("only registers keys starting with REPL_", () => {
@@ -107,13 +120,13 @@ describe("secret registry (taint propagation)", () => {
 });
 
 describe("secret registry (env seeding)", () => {
-	it("seeds secrets from REPL_* env vars, keeping the prefix", () => {
+	it("seeds secrets from REPL_* env vars, keeping the prefix (no description)", () => {
 		const prev = process.env.REPL_FOO;
 		process.env.REPL_FOO = "from-env";
 		try {
 			const interp = new Interp();
 			run(interp, prelude);
-			expect(str(run(interp, "(secrets)"))).toContain("REPL_FOO");
+			expect(str(run(interp, "(secrets)"))).toBe('(("REPL_FOO" . ""))');
 			expect(str(run(interp, '(secret "REPL_FOO")'))).toBe(
 				"#<secret:REPL_FOO>",
 			);
@@ -152,6 +165,16 @@ describe("secret registry (.env file loading)", () => {
 		expect(repl.eval("(secrets)")).toContain("REPL_FOO");
 	});
 
+	it("keeps descriptions across an AgentRepl reset()", () => {
+		const repl = new AgentRepl();
+		repl.setSecrets({
+			REPL_FOO: { value: "bar", description: "the foo token" },
+		});
+		expect(repl.eval("(secrets)")).toContain("the foo token");
+		repl.reset();
+		expect(repl.eval("(secrets)")).toContain("the foo token");
+	});
+
 	it("does not auto-load $LISPTC_SECRETS_FILE for an embedded AgentRepl", () => {
 		const path = writeEnvFile("REPL_PI_TOKEN=t0ken\n");
 		const prev = process.env.LISPTC_SECRETS_FILE;
@@ -182,8 +205,6 @@ describe("secret registry (revealed only into an MCP call)", () => {
 				`(await (load-mcp :name "fx" :command "node" :args (quote ("--experimental-transform-types" "${FIXTURE}"))))`,
 			),
 		);
-		// The echo fixture returns its :message argument verbatim, proving the
-		// real value is revealed on the way into the call.
 		expect(str(run(interp, '(fx/echo :message (secret "REPL_FOO"))'))).toBe(
 			'"s3cr3t"',
 		);

--- a/packages/interpreter/test/secrets.test.ts
+++ b/packages/interpreter/test/secrets.test.ts
@@ -100,24 +100,24 @@ describe("secret registry (.env file loading)", () => {
 		);
 	});
 
-	it("re-injects file-loaded secrets on AgentRepl reset()", () => {
+	it("re-injects explicitly-loaded secrets on AgentRepl reset()", () => {
 		const path = writeEnvFile("FOO=bar\n");
 		const repl = new AgentRepl();
+		// An embedder must opt in explicitly; AgentRepl does not auto-load .env.
 		repl.loadSecretsFromFile(path);
 		expect(repl.eval("(secrets)")).toContain("FOO");
 		repl.reset();
 		expect(repl.eval("(secrets)")).toContain("FOO");
 	});
 
-	it("auto-loads $LISPTC_SECRETS_FILE for an embedder (e.g. pi via AgentRepl)", () => {
+	it("does not auto-load $LISPTC_SECRETS_FILE for an embedded AgentRepl", () => {
 		const path = writeEnvFile("PI_TOKEN=t0ken\n");
 		const prev = process.env.LISPTC_SECRETS_FILE;
 		process.env.LISPTC_SECRETS_FILE = path;
 		try {
-			// A plain AgentRepl (no explicit setSecrets) picks the file up.
+			// A plain AgentRepl (the pi embedding) must NOT pick the file up.
 			const repl = new AgentRepl();
-			expect(repl.eval("(secrets)")).toContain("PI_TOKEN");
-			expect(repl.eval('(secret "PI_TOKEN")')).toContain("#<secret:PI_TOKEN>");
+			expect(repl.eval("(secrets)")).not.toContain("PI_TOKEN");
 		} finally {
 			if (prev === undefined) delete process.env.LISPTC_SECRETS_FILE;
 			else process.env.LISPTC_SECRETS_FILE = prev;

--- a/packages/interpreter/test/secrets.test.ts
+++ b/packages/interpreter/test/secrets.test.ts
@@ -11,9 +11,7 @@ const FIXTURE = fileURLToPath(
 	new URL("./fixture-mcp-server.ts", import.meta.url),
 );
 
-// Interpreter-level behaviour: secrets are ordinary strings; redaction is a
-// REPL concern (see the AgentRepl block below), so `ev` sees raw values.
-describe("secret registry (interpreter level)", () => {
+describe("secret registry", () => {
 	it("lists the keys of registered secrets (prefix kept)", () => {
 		const interp = freshInterp();
 		interp.setSecrets({ REPL_FOO: "bar", REPL_BAZ: "qux" });
@@ -33,62 +31,78 @@ describe("secret registry (interpreter level)", () => {
 		);
 	});
 
-	it("returns an empty list when no secrets are registered", () => {
-		expect(ev("(secrets)")).toBe("nil");
-	});
-
 	it("errors when reading an unknown secret", () => {
 		expect(() => ev('(secret "REPL_NOPE")')).toThrow(/unknown secret/);
 	});
 
-	it("is an ordinary string usable by any text function", () => {
+	it("always prints a secret redacted, never its value", () => {
 		const interp = freshInterp();
 		interp.setSecrets({ REPL_FOO: "s3cr3t" });
-		// A raw secret is just its value at the interpreter level.
-		expect(ev('(secret "REPL_FOO")', interp)).toBe('"s3cr3t"');
-		// Every string function works — concat, upcase, length, ...
-		expect(ev('(concat "Bearer " (secret "REPL_FOO"))', interp)).toBe(
-			'"Bearer s3cr3t"',
+		expect(ev('(secret "REPL_FOO")', interp)).toBe("#<secret:REPL_FOO>");
+		expect(ev('(list "a" (secret "REPL_FOO") "b")', interp)).toBe(
+			'("a" #<secret:REPL_FOO> "b")',
 		);
-		expect(ev('(string-upcase (secret "REPL_FOO"))', interp)).toBe('"S3CR3T"');
+	});
+
+	it("is a string: length and stringp work", () => {
+		const interp = freshInterp();
+		interp.setSecrets({ REPL_FOO: "s3cr3t" });
 		expect(ev('(length (secret "REPL_FOO"))', interp)).toBe("6");
+		expect(ev('(stringp (secret "REPL_FOO"))', interp)).toBe("t");
 	});
 });
 
-// The REPL redacts secret values out of everything it prints — returned
-// values and prin1/princ side-effect output alike.
-describe("secret registry (REPL redaction)", () => {
-	function replWithSecret(value: string): AgentRepl {
-		const repl = new AgentRepl();
-		repl.setSecrets({ REPL_FOO: value });
-		return repl;
+// Taint tracking: anything derived from a secret through a text function stays
+// a secret and prints redacted — so an agent cannot transform its way around
+// the redaction (upcase, reverse, substring, char, concat, ...).
+describe("secret registry (taint propagation)", () => {
+	function interpWith(value: string): Interp {
+		const interp = freshInterp();
+		interp.setSecrets({ REPL_FOO: value });
+		return interp;
 	}
 
-	it("redacts a returned secret value", () => {
-		const repl = replWithSecret("s3cr3t");
-		expect(repl.eval('(secret "REPL_FOO")').trim()).toBe(
-			'"#<secret:REPL_FOO>"',
+	it("stays redacted through string-upcase / string-downcase", () => {
+		const interp = interpWith("s3cr3t");
+		expect(ev('(string-upcase (secret "REPL_FOO"))', interp)).toBe(
+			"#<secret:REPL_FOO>",
+		);
+		expect(ev('(string-downcase (secret "REPL_FOO"))', interp)).toBe(
+			"#<secret:REPL_FOO>",
 		);
 	});
 
-	it("redacts side-effect (princ) output", () => {
-		const repl = replWithSecret("s3cr3t");
-		const out = repl.eval('(princ (secret "REPL_FOO"))');
-		expect(out).not.toContain("s3cr3t");
-		expect(out).toContain("#<secret:REPL_FOO>");
+	it("stays redacted through concat, char and substring", () => {
+		const interp = interpWith("s3cr3t");
+		expect(ev('(concat "Bearer " (secret "REPL_FOO"))', interp)).toBe(
+			"#<secret:REPL_FOO>",
+		);
+		expect(ev('(char (secret "REPL_FOO") 0)', interp)).toBe(
+			"#<secret:REPL_FOO>",
+		);
+		expect(ev('(substring (secret "REPL_FOO") 0 3)', interp)).toBe(
+			"#<secret:REPL_FOO>",
+		);
 	});
 
-	it("redacts a secret nested inside a composed string", () => {
-		const repl = replWithSecret("s3cr3t");
-		const out = repl.eval('(concat "Bearer " (secret "REPL_FOO"))').trim();
-		// The `Bearer ` text stays; only the secret value is masked.
-		expect(out).toBe('"Bearer #<secret:REPL_FOO>"');
-		expect(out).not.toContain("s3cr3t");
+	it("unions taint when two secrets are combined", () => {
+		const interp = freshInterp();
+		interp.setSecrets({ REPL_A: "aaa", REPL_B: "bbb" });
+		expect(ev('(concat (secret "REPL_A") (secret "REPL_B"))', interp)).toBe(
+			"#<secret:REPL_A+REPL_B>",
+		);
 	});
 
-	it("does not redact when nothing matches a secret value", () => {
-		const repl = replWithSecret("s3cr3t");
-		expect(repl.eval('(concat "a" "b")').trim()).toBe('"ab"');
+	it("still lets string predicates work on secrets (value compare)", () => {
+		const interp = interpWith("s3cr3t");
+		expect(ev('(string-prefix? "s3" (secret "REPL_FOO"))', interp)).toBe("t");
+		expect(ev('(string-contains? (secret "REPL_FOO") "cr")', interp)).toBe("t");
+	});
+
+	it("plain strings are untainted (no false redaction)", () => {
+		const interp = interpWith("s3cr3t");
+		expect(ev('(concat "a" "b")', interp)).toBe('"ab"');
+		expect(ev('(string-upcase "abc")', interp)).toBe('"ABC"');
 	});
 });
 
@@ -100,8 +114,9 @@ describe("secret registry (env seeding)", () => {
 			const interp = new Interp();
 			run(interp, prelude);
 			expect(str(run(interp, "(secrets)"))).toContain("REPL_FOO");
-			interp.setSecrets({ REPL_FOO: "from-host" });
-			expect(str(run(interp, '(secret "REPL_FOO")'))).toBe('"from-host"');
+			expect(str(run(interp, '(secret "REPL_FOO")'))).toBe(
+				"#<secret:REPL_FOO>",
+			);
 		} finally {
 			if (prev === undefined) delete process.env.REPL_FOO;
 			else process.env.REPL_FOO = prev;
@@ -151,7 +166,7 @@ describe("secret registry (.env file loading)", () => {
 	});
 });
 
-describe("secret registry (used in an MCP call)", () => {
+describe("secret registry (revealed only into an MCP call)", () => {
 	const interp = new Interp();
 	run(interp, prelude);
 	interp.setSecrets({ REPL_FOO: "s3cr3t" });
@@ -160,7 +175,7 @@ describe("secret registry (used in an MCP call)", () => {
 		run(interp, "(mcp-shutdown)");
 	});
 
-	it("passes the real value (and composed values) into an MCP tool call", () => {
+	it("passes the real (and composed) value into an MCP tool call", () => {
 		str(
 			run(
 				interp,
@@ -168,7 +183,7 @@ describe("secret registry (used in an MCP call)", () => {
 			),
 		);
 		// The echo fixture returns its :message argument verbatim, proving the
-		// real value (no redaction) reaches the tool.
+		// real value is revealed on the way into the call.
 		expect(str(run(interp, '(fx/echo :message (secret "REPL_FOO"))'))).toBe(
 			'"s3cr3t"',
 		);

--- a/packages/interpreter/test/secrets.test.ts
+++ b/packages/interpreter/test/secrets.test.ts
@@ -57,9 +57,9 @@ describe("secret registry", () => {
 });
 
 describe("secret registry (env seeding)", () => {
-	it("seeds secrets from LISPTC_SECRET_* env vars, overridable by setSecrets", () => {
-		const prev = process.env.LISPTC_SECRET_FOO;
-		process.env.LISPTC_SECRET_FOO = "from-env";
+	it("seeds secrets from REPL_* env vars, overridable by setSecrets", () => {
+		const prev = process.env.REPL_FOO;
+		process.env.REPL_FOO = "from-env";
 		try {
 			const interp = new Interp();
 			run(interp, prelude);
@@ -71,8 +71,8 @@ describe("secret registry (env seeding)", () => {
 			interp.setSecrets({ FOO: "from-host" });
 			expect(str(run(interp, '(secret "FOO")'))).toBe("#<secret:FOO>");
 		} finally {
-			if (prev === undefined) delete process.env.LISPTC_SECRET_FOO;
-			else process.env.LISPTC_SECRET_FOO = prev;
+			if (prev === undefined) delete process.env.REPL_FOO;
+			else process.env.REPL_FOO = prev;
 		}
 	});
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,12 +20,21 @@ importers:
       '@commitlint/types':
         specifier: ^21.2.0
         version: 21.2.0
+      '@infisical/sdk':
+        specifier: ^5.0.2
+        version: 5.0.2
+      cmd-ts:
+        specifier: ^0.15.0
+        version: 0.15.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7
       knip:
         specifier: ^6.27.0
         version: 6.27.0
+      tsx:
+        specifier: ^4.23.1
+        version: 4.23.1
       turbo:
         specifier: ^2.5.0
         version: 2.10.5
@@ -97,7 +106,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.0.0
-        version: 3.2.7(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0)
+        version: 3.2.7(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       zod:
         specifier: ^4.4.3
         version: 4.4.3
@@ -130,8 +139,20 @@ packages:
     resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-cognito-identity@3.993.0':
+    resolution: {integrity: sha512-7Ne3Yk/bgQPVebAkv7W+RfhiwTRSbfER9BtbhOa2w/+dIr902LrJf6vrZlxiqaJbGj2ALx8M+ZK1YIHVxSwu9A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/core@3.975.3':
     resolution: {integrity: sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.977.4':
+    resolution: {integrity: sha512-CEkcQlMOQJCvul60U7wdAOACjtdgFWDsfJI+6wUOGdhGNV2lGbuJpi/R50QLpFG3Tp+sQxa/RmzC3X7KHbhuTA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.64':
+    resolution: {integrity: sha512-bilBheDT6GKnFkPnovgt1HL5spmnTCntm8w+hO3bmjnlZ8qMhqfQ1RJYPRTNsPlXaCcBXWUtg+zn/NM6WQUXoA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-env@3.972.59':
@@ -166,6 +187,10 @@ packages:
     resolution: {integrity: sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-providers@3.993.0':
+    resolution: {integrity: sha512-1M/nukgPSLqe9krzOKHnE8OylUaKAiokAV3xRLdeExVHcRE7WG5uzCTKWTj1imKvPjDqXq/FWhlbbdWIn7xIwA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/eventstream-handler-node@3.972.28':
     resolution: {integrity: sha512-XV5sEH1xH5oydNgvUH87CR8BA2SBZXltckteS17D7ZT2k2THIBiExO9TEBYcgqUU31WAIfBH2hmx+fhFMiTL4Q==}
     engines: {node: '>=20.0.0'}
@@ -174,16 +199,48 @@ packages:
     resolution: {integrity: sha512-oykin4mDWxNOuYQ7SF1cHzgYeuFEkF4cdRwgvjFFbIklkx09qIFBiOgsORafG9sXZFO3TayMmQuAQYgADXhI8w==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-host-header@3.972.40':
+    resolution: {integrity: sha512-e9s+NNwXzY6at4A/B6gwS+MKK5jeS9wPWPBQFqrxPrwjEmhCWd6Gx8txH4yB68uMpyCEl7Sz/DhoEKsWBkiXYQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-logger@3.972.39':
+    resolution: {integrity: sha512-Nu7yC2lm9jQyyrseaNQ612zbW+aTA8bjjnp3uDXtPUQWZxhe5kyFSJCN+cBTnijsjSfMWFcqo5nDGc9Fya5+kQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-recursion-detection@3.972.41':
+    resolution: {integrity: sha512-3illdV11CWK4qmlG3jXNoVtEdguvS11beM/Pzn5fC6dqdUNN6zqgLbds3oPExo1ttuieNwluQN7h1trFkU6RPw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/middleware-user-agent@3.972.69':
+    resolution: {integrity: sha512-mxjPSwBIAHdAskfS/kJuJuyMwjxN4T2m/ElKxw73jgOfIRr6MCUwxLGxdfZoZy19bO4SEqOYibYDZN2ssGjtcA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/middleware-websocket@3.972.41':
     resolution: {integrity: sha512-LSbGvvYmjc4Br9BPYI2dTLnIclmrSiQbahkP4D6nRGVEv4qsCZ8csVuKBPVEEFCVD+EEngGh8ROls6XpumtwMg==}
     engines: {node: '>= 14.0.0'}
+
+  '@aws-sdk/nested-clients@3.993.0':
+    resolution: {integrity: sha512-iOq86f2H67924kQUIPOAvlmMaOAvOLoDOIb66I2YqSUpMYB6ufiuJW3RlREgskxv86S5qKzMnfy/X6CqMjK6XQ==}
+    engines: {node: '>=20.0.0'}
 
   '@aws-sdk/nested-clients@3.997.33':
     resolution: {integrity: sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.39':
+    resolution: {integrity: sha512-wU5NPnj62Sb7A8xn/Zb+xThe05P3otNtDl37iOIi5DDMeCesNeCckaG+eXWGUs12Z9R34I8CD05TaTe6SIa61g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/region-config-resolver@3.972.43':
+    resolution: {integrity: sha512-bQJi00IX9YpZ3P0C14DhNAt/Elllf0Pfg0k7Aj65K63ZJLLonDKHGLTgauqtohyAlo4OB6SHBW8v9yBfjvV66g==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.41':
     resolution: {integrity: sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    resolution: {integrity: sha512-lKekx8bLBXSv4O+cslk9Zfnw2XKSkWBs3uWL5QGhH2ZAQfNS7FE0vcSSN2vD/AhxX54ZTywWxR4STThoeOXlBA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1048.0':
@@ -198,12 +255,27 @@ packages:
     resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/util-endpoints@3.993.0':
+    resolution: {integrity: sha512-j6vioBeRZ4eHX4SWGvGPpwGg/xSOcK7f1GL0VM+rdf3ZFTIsUEhCFmD78B+5r2PgztcECSzEfvHQX01k8dPQPw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/util-locate-window@3.965.8':
     resolution: {integrity: sha512-uUbMs1cBZPafD0ohUj6EwNf0fPZ534NvBxHox4hjX+0Rxq5paSYUem7+hi833pYrzrcnBATKIYpR02MDXT5M9g==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/util-user-agent-browser@3.972.40':
+    resolution: {integrity: sha512-supWvw8+F8ln6ZhYUmFCbxOJuwpqwPZmnajnR2JdLnwcLbk9YLKe9Nz5vDDuNzNSoGwAxVh5HOiQ14mGpSgseA==}
+
+  '@aws-sdk/util-user-agent-node@3.973.55':
+    resolution: {integrity: sha512-K8hE8pENjibXjcv7Hizsc5nnmcVD03Y40Ls/8YcHZBjlxslhBMCKDjotPtrHowabcCIscoNvBE69DuK1Wl0GtA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/xml-builder@3.972.36':
     resolution: {integrity: sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.37':
+    resolution: {integrity: sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.3.0':
@@ -563,6 +635,10 @@ packages:
     engines: {node: '>=18.14.1'}
     peerDependencies:
       hono: ^4
+
+  '@infisical/sdk@5.0.2':
+    resolution: {integrity: sha512-mkgghtmIgBOEOFj1gb2n/AoiroFvN+NqaEEwC8ezEQ87V55yf2yksHhnBMU2MiZ26n6b3sGcpDZHF1/H6JrgyA==}
+    engines: {node: '>=20'}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
@@ -1045,45 +1121,149 @@ packages:
   '@sinclair/typebox@0.34.52':
     resolution: {integrity: sha512-XiMQh7qqVlxZzcVD+kkGMNGMzcTrDMLWI7S4x7z1MkCkbDPrekpZXEUK0eZqZFMuHQg2a2DZOcDIh9o5v3Gonw==}
 
+  '@smithy/config-resolver@4.6.16':
+    resolution: {integrity: sha512-XMDfb7LTrlUeI9PpfMa6xzRv+yMtYFsr1LqTsR3CGpSSaaPIR5ldlAiXyLjFYmbh1/DD5NxHmDybdh6lJjJM+Q==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/core@3.29.5':
     resolution: {integrity: sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/core@3.31.1':
+    resolution: {integrity: sha512-CyogUINxvi7C7LDsh8Syo6hVJOT9ckz4rG8dRZfTJ8r91HkMY59PnNooaj7WcHyxEkxPfBAmbgztZU+xTo76lg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/credential-provider-imds@4.4.10':
     resolution: {integrity: sha512-MJenAe4OKRZUo1LdYYFDCsSHxaHvInIU/z52GsheO9vl1/VSySVCr0zkyKD6TFiGkSUaWGxvKZ/70OvgUZR5HQ==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/fetch-http-handler@5.6.13':
+    resolution: {integrity: sha512-4fW86pEUOMbrD5nkbyl/tTvPHHWJFbuB2odl6ps9lWfHoXf9HWh3Q/Smh59qH1g7+c/BSZghX6bbUk4gsiMs8A==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/fetch-http-handler@5.6.7':
     resolution: {integrity: sha512-3zpg8yqqyXzoK2TsRDdkqVOj2RDBFfLXwCczOZ5c7TWB4eiaebfSCsbMjDPYB3PJ9ihV62QaeadZ+wLadZtNGA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/hash-node@4.4.16':
+    resolution: {integrity: sha512-9NJHd8scrdVORvnaMHIHgPipGxLiTK3FMNUfWl0tHn2fwJIEk4rZ3OM793yIWV8L+WKu+AWQZBcVyd5qrVXy+A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/invalid-dependency@4.4.16':
+    resolution: {integrity: sha512-fEXR2jKLnu1U9sL/Obdkxs8f3M1pLSDjM30cMmpz2L61oGnlUdx1Z9Wj+9+mID7kKldEVOUQfuXqHrK4RP90FA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
 
+  '@smithy/middleware-content-length@4.4.16':
+    resolution: {integrity: sha512-Q+J8iTUHr5qtoejFJCb9TTavDh7xQFVFRjy1n1edq5BFJq5b4mfziqrEqJlAscHHVdsqyFTNJXcV+b9i3oad9w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-endpoint@4.6.16':
+    resolution: {integrity: sha512-nU2N3LY6Vn46rwga1+gZQJ1Zsu+3/Qj2X+d5gKb8gSvLmojZd0sg9XWYqMDH59VeadVKOGOhMrhyzUo7ln4lGw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-retry@4.7.16':
+    resolution: {integrity: sha512-JOVvyFbNiXUuT8Id+uNIEzbkqi8IOa6zqEQgzpoQ1xYIQQFTFL/mXIiBRLlA129aoBB1EeiElkhmLZyok5axYA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-serde@4.4.16':
+    resolution: {integrity: sha512-nwYV4tBUU5kBOYec2p8vKz5pzMVWVEcalVY4ZXguUdZZEOm9LQZhT0pKsnYSQhldvWegaFKWAR45Mi4XUfv5cQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/middleware-stack@4.4.16':
+    resolution: {integrity: sha512-IivXdOXykxp8Eq+qDL91mxEVd9CoR7wEIJqhJiwbHnmJVX6SZm2hxZt6uSDQOEh5tYHQdj6WuqmpNhV7P8C1Ww==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-config-provider@4.5.16':
+    resolution: {integrity: sha512-N4XTMCO77u8jXq9Ms1pbFM3M9zD+ScKnvB+M7//VyawM8L6xW3/mqAPp/uMOYprW+q/b1Qen6qUKVwxTb2ymiQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/node-http-handler@4.7.3':
     resolution: {integrity: sha512-/jPhevcTFPMVl6KNjbaI47iOg1zxC7IsnX4PQDGVZKMFceOXtB8IEYaB7a9VvkP/3oC60WzTeKocvSI7vLT0vA==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/node-http-handler@4.9.13':
+    resolution: {integrity: sha512-Nmd/Nl35zfYrd+a6OO2cDJb3GPh9bgTjIUhcM+JFfjpp8/osCgboDV5nCT1I01Pv6R13eSKDKLSoVa5ZB6Zsfw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/node-http-handler@4.9.7':
     resolution: {integrity: sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/property-provider@4.4.16':
+    resolution: {integrity: sha512-xsj0qoE3ya7Fu3YoyKPINtGWsY33IO2ypcOJpLAGMbzGYTNr0wqK0HnCroHRIoJTsHapnsFABUhzlNfHo/diwg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/protocol-http@5.5.16':
+    resolution: {integrity: sha512-iPaxIe9mTyidyhM6WF2/gSLPezyCwSlZcqlDBj2KCoSS994iw4yf1se1xmZkWsY98ZpwjDR/ZMubOSVx+Nrokw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.12':
+    resolution: {integrity: sha512-I6KLtq3H0qqSuV9vLglfi8puHqzygzWHOnI4z/Rdoo+q50vvo18vBRdPAvvEtcaKROz7Zn6qnPa14kRfPH6PcQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/signature-v4@5.6.6':
     resolution: {integrity: sha512-efP6DN3UTFrzIsGO42/xcabv8jU7+9nwEdphFUH7yL0k010ERyAWaO41KFQIDLcFZLZ8xzIQr4wplFxNzslSGQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/smithy-client@4.14.16':
+    resolution: {integrity: sha512-UzWzH88hntrIn1wMPlmt/6vmQL+FS+pYgqvBsp4QQdgt/DUFZZD0S0xRO7kCfAfz9fqn9boVb+buFWU4LD9PJg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/types@4.16.1':
     resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/url-parser@4.4.16':
+    resolution: {integrity: sha512-0VynNn3o4qSpRbgtG6RbT09wsN2HjsIkBvxHUX99p0t3sFj7hvqsOtPQBubawSNH4PWfwXgkD82vG166ROta7w==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-base64@4.5.16':
+    resolution: {integrity: sha512-80e25qWKD6hJh5BenAutni2Z6dj2AiZKmht21pcROmzWzQja8yl+KqsuDSia++hwk1Ne6RrDEBwP6I+A4R0XAg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-browser@4.4.16':
+    resolution: {integrity: sha512-gTqO1MkKFsaKgJoGelxgWBdUlHqc9g1z6ItBVFsQU1yTO4W6BEIq/NZIDf/UTi6ueojTr2fJRetusBIbctA6KQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-body-length-node@4.4.16':
+    resolution: {integrity: sha512-BTwIXGhunFzjNYpKrRJJjgfEONT8m/wyBB0IL4BWB9WqJSQa/CEMh2cPHqbqMpKwnAljPuhhbGwF2Z0qm2C04A==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-buffer-from@2.2.0':
     resolution: {integrity: sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==}
     engines: {node: '>=14.0.0'}
 
+  '@smithy/util-defaults-mode-browser@4.5.16':
+    resolution: {integrity: sha512-en8XtoFeELWwI0pwpmUbf63bJ9WRusVozGQ59mE9YuUuW+Q/FFRfdbd/EZIf/p1oZXHerbj30ITuer7vE47TbQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-defaults-mode-node@4.4.16':
+    resolution: {integrity: sha512-MAN0jEah3skK3+94QiikeLbuhnZ9GuW+JCjuIUpXGUvJG2U4N8sscypWDMUJUkKc6DYJ0UaGI5Xvb17crXwyiw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-endpoints@3.6.16':
+    resolution: {integrity: sha512-7dFFv+DA2Ln8s60s+JIRHHfl/Fch8HZ3FY9VjnM6I3EtigDP+bUUexNQZuexVYJXUejpQ48/JIHSiSmugFDD/A==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-middleware@4.4.16':
+    resolution: {integrity: sha512-VuChjNaV9VteddlugHsGqFXgjQK8WIt9JxYAtdsi1i8A1PwrVAVC6DVVRqr9XbGeWnHvvWb0ywWLMjYUZwiHYg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/util-retry@4.5.16':
+    resolution: {integrity: sha512-oM/8/5H9aG1omF2CzDxE7oxiJQhkonS2Vz1Kd6/76IhvPzCoroA3RVhr0EhAhZmyY6th3WfLK0OpRrphJ3YbgQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/util-utf8@2.3.0':
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
+
+  '@smithy/util-utf8@4.4.16':
+    resolution: {integrity: sha512-/gSbVMQlLRcneJ8D/JGbB1DNf0w4I7OpY2ldNUJ+myDmakPXEm9fy/X4swDlNYTOwBwsCKVJsogCfe7Txjnolg==}
+    engines: {node: '>=18.0.0'}
 
   '@turbo/darwin-64@2.10.5':
     resolution: {integrity: sha512-ENvPwy3x5yS7MwNYHeWjqOBXkwIMp39Pd+/zXC6PoiNzF8EIvvLZOZZ+ny6L9x4WgS5vxUii2LM5gM+zjPdnWw==}
@@ -1260,6 +1440,9 @@ packages:
     resolution: {integrity: sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==}
     engines: {node: '>=20'}
 
+  cmd-ts@0.15.0:
+    resolution: {integrity: sha512-ASyAx+P6DNzNEZ6OYmvjjaLAQeI3L+4lm5rX2Jg8tondXdj06o9JTxi9mfC92KoVbrVFKhZ+j2TfBF8fcura6g==}
+
   content-disposition@1.1.0:
     resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
     engines: {node: '>=18'}
@@ -1338,6 +1521,9 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  didyoumean@1.2.2:
+    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
@@ -1995,6 +2181,11 @@ packages:
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
+  tsx@4.23.1:
+    resolution: {integrity: sha512-GQHnkIfxyx1wYCOS/wonik5MVRZU9hi1TEZmzGZSCJB1y9YgoZ8H6itNE/u4suE+yLmOzuE4E5S4TZ/ZX2wcWQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
   turbo@2.10.5:
     resolution: {integrity: sha512-07Y/C7OUp23l4P92PJoYtFNbHjLhftrZH5Ce7dbczS4kX2Re+wtbXvZLoxn/pUtzgsQaRCBaRuZPJp4zmAn0WQ==}
     hasBin: true
@@ -2179,6 +2370,9 @@ packages:
     peerDependencies:
       zod: ^3.25.28 || ^4
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -2233,6 +2427,48 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/client-cognito-identity@3.993.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/credential-provider-node': 3.972.69
+      '@aws-sdk/middleware-host-header': 3.972.40
+      '@aws-sdk/middleware-logger': 3.972.39
+      '@aws-sdk/middleware-recursion-detection': 3.972.41
+      '@aws-sdk/middleware-user-agent': 3.972.69
+      '@aws-sdk/region-config-resolver': 3.972.43
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/util-endpoints': 3.993.0
+      '@aws-sdk/util-user-agent-browser': 3.972.40
+      '@aws-sdk/util-user-agent-node': 3.973.55
+      '@smithy/config-resolver': 4.6.16
+      '@smithy/core': 3.29.5
+      '@smithy/fetch-http-handler': 5.6.7
+      '@smithy/hash-node': 4.4.16
+      '@smithy/invalid-dependency': 4.4.16
+      '@smithy/middleware-content-length': 4.4.16
+      '@smithy/middleware-endpoint': 4.6.16
+      '@smithy/middleware-retry': 4.7.16
+      '@smithy/middleware-serde': 4.4.16
+      '@smithy/middleware-stack': 4.4.16
+      '@smithy/node-config-provider': 4.5.16
+      '@smithy/node-http-handler': 4.9.7
+      '@smithy/protocol-http': 5.5.16
+      '@smithy/smithy-client': 4.14.16
+      '@smithy/types': 4.16.1
+      '@smithy/url-parser': 4.4.16
+      '@smithy/util-base64': 4.5.16
+      '@smithy/util-body-length-browser': 4.4.16
+      '@smithy/util-body-length-node': 4.4.16
+      '@smithy/util-defaults-mode-browser': 4.5.16
+      '@smithy/util-defaults-mode-node': 4.4.16
+      '@smithy/util-endpoints': 3.6.16
+      '@smithy/util-middleware': 4.4.16
+      '@smithy/util-retry': 4.5.16
+      '@smithy/util-utf8': 4.4.16
+      tslib: 2.8.1
+
   '@aws-sdk/core@3.975.3':
     dependencies:
       '@aws-sdk/types': 3.974.2
@@ -2242,6 +2478,25 @@ snapshots:
       '@smithy/signature-v4': 5.6.6
       '@smithy/types': 4.16.1
       bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/core@3.977.4':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.37
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.31.1
+      '@smithy/signature-v4': 5.6.12
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-cognito-identity@3.972.64':
+    dependencies:
+      '@aws-sdk/nested-clients': 3.997.39
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-env@3.972.59':
@@ -2328,6 +2583,29 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-providers@3.993.0':
+    dependencies:
+      '@aws-sdk/client-cognito-identity': 3.993.0
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/credential-provider-cognito-identity': 3.972.64
+      '@aws-sdk/credential-provider-env': 3.972.59
+      '@aws-sdk/credential-provider-http': 3.972.61
+      '@aws-sdk/credential-provider-ini': 3.973.3
+      '@aws-sdk/credential-provider-login': 3.972.65
+      '@aws-sdk/credential-provider-node': 3.972.69
+      '@aws-sdk/credential-provider-process': 3.972.59
+      '@aws-sdk/credential-provider-sso': 3.973.3
+      '@aws-sdk/credential-provider-web-identity': 3.972.65
+      '@aws-sdk/nested-clients': 3.993.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/config-resolver': 4.6.16
+      '@smithy/core': 3.29.5
+      '@smithy/credential-provider-imds': 4.4.10
+      '@smithy/node-config-provider': 4.5.16
+      '@smithy/property-provider': 4.4.16
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/eventstream-handler-node@3.972.28':
     dependencies:
       '@aws-sdk/types': 3.974.2
@@ -2342,6 +2620,26 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-host-header@3.972.40':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-logger@3.972.39':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-recursion-detection@3.972.41':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      tslib: 2.8.1
+
+  '@aws-sdk/middleware-user-agent@3.972.69':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      tslib: 2.8.1
+
   '@aws-sdk/middleware-websocket@3.972.41':
     dependencies:
       '@aws-sdk/core': 3.975.3
@@ -2350,6 +2648,47 @@ snapshots:
       '@smithy/fetch-http-handler': 5.6.7
       '@smithy/signature-v4': 5.6.6
       '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/nested-clients@3.993.0':
+    dependencies:
+      '@aws-crypto/sha256-browser': 5.2.0
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/middleware-host-header': 3.972.40
+      '@aws-sdk/middleware-logger': 3.972.39
+      '@aws-sdk/middleware-recursion-detection': 3.972.41
+      '@aws-sdk/middleware-user-agent': 3.972.69
+      '@aws-sdk/region-config-resolver': 3.972.43
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/util-endpoints': 3.993.0
+      '@aws-sdk/util-user-agent-browser': 3.972.40
+      '@aws-sdk/util-user-agent-node': 3.973.55
+      '@smithy/config-resolver': 4.6.16
+      '@smithy/core': 3.29.5
+      '@smithy/fetch-http-handler': 5.6.7
+      '@smithy/hash-node': 4.4.16
+      '@smithy/invalid-dependency': 4.4.16
+      '@smithy/middleware-content-length': 4.4.16
+      '@smithy/middleware-endpoint': 4.6.16
+      '@smithy/middleware-retry': 4.7.16
+      '@smithy/middleware-serde': 4.4.16
+      '@smithy/middleware-stack': 4.4.16
+      '@smithy/node-config-provider': 4.5.16
+      '@smithy/node-http-handler': 4.9.7
+      '@smithy/protocol-http': 5.5.16
+      '@smithy/smithy-client': 4.14.16
+      '@smithy/types': 4.16.1
+      '@smithy/url-parser': 4.4.16
+      '@smithy/util-base64': 4.5.16
+      '@smithy/util-body-length-browser': 4.4.16
+      '@smithy/util-body-length-node': 4.4.16
+      '@smithy/util-defaults-mode-browser': 4.5.16
+      '@smithy/util-defaults-mode-node': 4.4.16
+      '@smithy/util-endpoints': 3.6.16
+      '@smithy/util-middleware': 4.4.16
+      '@smithy/util-retry': 4.5.16
+      '@smithy/util-utf8': 4.4.16
       tslib: 2.8.1
 
   '@aws-sdk/nested-clients@3.997.33':
@@ -2363,10 +2702,33 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.39':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      '@aws-sdk/signature-v4-multi-region': 3.996.43
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.1
+      '@smithy/fetch-http-handler': 5.6.13
+      '@smithy/node-http-handler': 4.9.13
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/region-config-resolver@3.972.43':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.41':
     dependencies:
       '@aws-sdk/types': 3.974.2
       '@smithy/signature-v4': 5.6.6
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.43':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/signature-v4': 5.6.12
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -2393,11 +2755,34 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@aws-sdk/util-endpoints@3.993.0':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/types': 4.16.1
+      '@smithy/url-parser': 4.4.16
+      '@smithy/util-endpoints': 3.6.16
+      tslib: 2.8.1
+
   '@aws-sdk/util-locate-window@3.965.8':
     dependencies:
       tslib: 2.8.1
 
+  '@aws-sdk/util-user-agent-browser@3.972.40':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      tslib: 2.8.1
+
+  '@aws-sdk/util-user-agent-node@3.973.55':
+    dependencies:
+      '@aws-sdk/core': 3.977.4
+      tslib: 2.8.1
+
   '@aws-sdk/xml-builder@3.972.36':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.37':
     dependencies:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
@@ -2760,6 +3145,15 @@ snapshots:
     dependencies:
       hono: 4.12.30
 
+  '@infisical/sdk@5.0.2':
+    dependencies:
+      '@aws-crypto/sha256-js': 5.2.0
+      '@aws-sdk/credential-providers': 3.993.0
+      '@smithy/protocol-http': 5.5.16
+      '@smithy/signature-v4': 5.6.6
+      typescript: 5.9.3
+      zod: 3.25.76
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
   '@mariozechner/clipboard-darwin-arm64@0.3.9':
@@ -3090,7 +3484,17 @@ snapshots:
 
   '@sinclair/typebox@0.34.52': {}
 
+  '@smithy/config-resolver@4.6.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      tslib: 2.8.1
+
   '@smithy/core@3.29.5':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/core@3.31.1':
     dependencies:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
@@ -3101,19 +3505,71 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@smithy/fetch-http-handler@5.6.13':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/fetch-http-handler@5.6.7':
     dependencies:
       '@smithy/core': 3.29.5
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@smithy/hash-node@4.4.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      tslib: 2.8.1
+
+  '@smithy/invalid-dependency@4.4.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      tslib: 2.8.1
+
   '@smithy/is-array-buffer@2.2.0':
     dependencies:
+      tslib: 2.8.1
+
+  '@smithy/middleware-content-length@4.4.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-endpoint@4.6.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-retry@4.7.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-serde@4.4.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      tslib: 2.8.1
+
+  '@smithy/middleware-stack@4.4.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      tslib: 2.8.1
+
+  '@smithy/node-config-provider@4.5.16':
+    dependencies:
+      '@smithy/core': 3.31.1
       tslib: 2.8.1
 
   '@smithy/node-http-handler@4.7.3':
     dependencies:
       '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/node-http-handler@4.9.13':
+    dependencies:
+      '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -3123,9 +3579,31 @@ snapshots:
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
+  '@smithy/property-provider@4.4.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      tslib: 2.8.1
+
+  '@smithy/protocol-http@5.5.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.12':
+    dependencies:
+      '@smithy/core': 3.31.1
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/signature-v4@5.6.6':
     dependencies:
       '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/smithy-client@4.14.16':
+    dependencies:
+      '@smithy/core': 3.31.1
       '@smithy/types': 4.16.1
       tslib: 2.8.1
 
@@ -3133,14 +3611,64 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@smithy/url-parser@4.4.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      tslib: 2.8.1
+
+  '@smithy/util-base64@4.5.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-browser@4.4.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      tslib: 2.8.1
+
+  '@smithy/util-body-length-node@4.4.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      tslib: 2.8.1
+
   '@smithy/util-buffer-from@2.2.0':
     dependencies:
       '@smithy/is-array-buffer': 2.2.0
       tslib: 2.8.1
 
+  '@smithy/util-defaults-mode-browser@4.5.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      tslib: 2.8.1
+
+  '@smithy/util-defaults-mode-node@4.4.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      tslib: 2.8.1
+
+  '@smithy/util-endpoints@3.6.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      tslib: 2.8.1
+
+  '@smithy/util-middleware@4.4.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      tslib: 2.8.1
+
+  '@smithy/util-retry@4.5.16':
+    dependencies:
+      '@smithy/core': 3.31.1
+      tslib: 2.8.1
+
   '@smithy/util-utf8@2.3.0':
     dependencies:
       '@smithy/util-buffer-from': 2.2.0
+      tslib: 2.8.1
+
+  '@smithy/util-utf8@4.4.16':
+    dependencies:
+      '@smithy/core': 3.31.1
       tslib: 2.8.1
 
   '@turbo/darwin-64@2.10.5':
@@ -3189,13 +3717,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.7(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))':
+  '@vitest/mocker@3.2.7(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.7
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
 
   '@vitest/pretty-format@3.2.7':
     dependencies:
@@ -3313,6 +3841,15 @@ snapshots:
       strip-ansi: 7.2.0
       wrap-ansi: 9.0.2
 
+  cmd-ts@0.15.0:
+    dependencies:
+      chalk: 5.6.2
+      debug: 4.4.3
+      didyoumean: 1.2.2
+      strip-ansi: 7.2.0
+    transitivePeerDependencies:
+      - supports-color
+
   content-disposition@1.1.0: {}
 
   content-type@1.0.5: {}
@@ -3372,6 +3909,8 @@ snapshots:
   deep-eql@5.0.2: {}
 
   depd@2.0.0: {}
+
+  didyoumean@1.2.2: {}
 
   diff@8.0.4: {}
 
@@ -4105,6 +4644,12 @@ snapshots:
 
   tslib@2.8.1: {}
 
+  tsx@4.23.1:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   turbo@2.10.5:
     optionalDependencies:
       '@turbo/darwin-64': 2.10.5
@@ -4134,13 +4679,13 @@ snapshots:
 
   vary@1.1.2: {}
 
-  vite-node@3.2.4(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0):
+  vite-node@3.2.4(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -4155,7 +4700,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0):
+  vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       esbuild: 0.28.1
       fdir: 6.5.0(picomatch@4.0.5)
@@ -4167,13 +4712,14 @@ snapshots:
       '@types/node': 22.20.1
       fsevents: 2.3.3
       jiti: 2.7.0
+      tsx: 4.23.1
       yaml: 2.9.0
 
-  vitest@3.2.7(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0):
+  vitest@3.2.7(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.7
-      '@vitest/mocker': 3.2.7(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.7(vite@7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0))
       '@vitest/pretty-format': 3.2.7
       '@vitest/runner': 3.2.7
       '@vitest/snapshot': 3.2.7
@@ -4191,8 +4737,8 @@ snapshots:
       tinyglobby: 0.2.17
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@22.20.1)(jiti@2.7.0)(yaml@2.9.0)
+      vite: 7.3.6(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@22.20.1)(jiti@2.7.0)(tsx@4.23.1)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.20.1
@@ -4266,5 +4812,7 @@ snapshots:
   zod-to-json-schema@3.25.2(zod@4.4.3):
     dependencies:
       zod: 4.4.3
+
+  zod@3.25.76: {}
 
   zod@4.4.3: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,6 +85,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.12.0
         version: 1.29.0(zod@4.4.3)
+      dotenv:
+        specifier: ^17.4.2
+        version: 17.4.2
     devDependencies:
       '@types/node':
         specifier: ^22.0.0
@@ -1339,6 +1342,10 @@ packages:
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
     engines: {node: '>=0.3.1'}
+
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
+    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -3367,6 +3374,8 @@ snapshots:
   depd@2.0.0: {}
 
   diff@8.0.4: {}
+
+  dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,11 +89,30 @@ importers:
         specifier: ^5.9.3
         version: 5.9.3
 
+  packages/env:
+    dependencies:
+      '@t3-oss/env-core':
+        specifier: ^0.13.11
+        version: 0.13.11(typescript@5.9.3)(zod@4.4.3)
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+
   packages/interpreter:
     dependencies:
       '@modelcontextprotocol/sdk':
         specifier: ^1.12.0
         version: 1.29.0(zod@4.4.3)
+      '@repo/env':
+        specifier: workspace:*
+        version: link:../env
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -1264,6 +1283,23 @@ packages:
   '@smithy/util-utf8@4.4.16':
     resolution: {integrity: sha512-/gSbVMQlLRcneJ8D/JGbB1DNf0w4I7OpY2ldNUJ+myDmakPXEm9fy/X4swDlNYTOwBwsCKVJsogCfe7Txjnolg==}
     engines: {node: '>=18.0.0'}
+
+  '@t3-oss/env-core@0.13.11':
+    resolution: {integrity: sha512-sM7GYY+KL7H/Hl0BE0inWfk3nRHZOLhmVn7sHGxaZt9FAR6KqREXAE+6TqKfiavfXmpRxO/OZ2QgKRd+oiBYRQ==}
+    peerDependencies:
+      arktype: ^2.1.0
+      typescript: '>=5.0.0'
+      valibot: ^1.0.0-beta.7 || ^1.0.0
+      zod: ^3.24.0 || ^4.0.0
+    peerDependenciesMeta:
+      arktype:
+        optional: true
+      typescript:
+        optional: true
+      valibot:
+        optional: true
+      zod:
+        optional: true
 
   '@turbo/darwin-64@2.10.5':
     resolution: {integrity: sha512-ENvPwy3x5yS7MwNYHeWjqOBXkwIMp39Pd+/zXC6PoiNzF8EIvvLZOZZ+ny6L9x4WgS5vxUii2LM5gM+zjPdnWw==}
@@ -3670,6 +3706,11 @@ snapshots:
     dependencies:
       '@smithy/core': 3.31.1
       tslib: 2.8.1
+
+  '@t3-oss/env-core@0.13.11(typescript@5.9.3)(zod@4.4.3)':
+    optionalDependencies:
+      typescript: 5.9.3
+      zod: 4.4.3
 
   '@turbo/darwin-64@2.10.5':
     optional: true

--- a/scripts/infisical-run.ts
+++ b/scripts/infisical-run.ts
@@ -38,6 +38,12 @@ const infisicalRun = command({
 			long: "projectId",
 			description: "Infisical project identifier containing the secrets",
 		}),
+		url: option({
+			type: string,
+			long: "url",
+			description: "Base URL of the Infisical instance",
+			defaultValue: () => "https://app.infisical.com",
+		}),
 		env: option({
 			type: oneOf(["dev", "stage", "prod"]),
 			long: "env",
@@ -63,7 +69,7 @@ const infisicalRun = command({
 			description: "Command to execute with injected secrets",
 		}),
 	},
-	handler: async ({ env, projectId, paths, dir, cmd }) => {
+	handler: async ({ url, env, projectId, paths, dir, cmd }) => {
 		const processedPaths = paths.split(" ").filter((path) => path !== "");
 
 		const clientId = process.env.INFISICAL_CLIENT_ID;
@@ -81,7 +87,9 @@ const infisicalRun = command({
 			);
 		}
 
-		const client = new InfisicalSDK();
+		const client = new InfisicalSDK({
+			siteUrl: url,
+		});
 
 		try {
 			await client.auth().universalAuth.login({

--- a/scripts/infisical-run.ts
+++ b/scripts/infisical-run.ts
@@ -38,12 +38,6 @@ const infisicalRun = command({
 			long: "projectId",
 			description: "Infisical project identifier containing the secrets",
 		}),
-		url: option({
-			type: string,
-			long: "url",
-			description: "Base URL of the Infisical instance",
-			defaultValue: () => "https://app.infisical.com",
-		}),
 		env: option({
 			type: oneOf(["dev", "stage", "prod"]),
 			long: "env",
@@ -69,7 +63,7 @@ const infisicalRun = command({
 			description: "Command to execute with injected secrets",
 		}),
 	},
-	handler: async ({ url, env, projectId, paths, dir, cmd }) => {
+	handler: async ({ env, projectId, paths, dir, cmd }) => {
 		const processedPaths = paths.split(" ").filter((path) => path !== "");
 
 		const clientId = process.env.INFISICAL_CLIENT_ID;
@@ -87,9 +81,7 @@ const infisicalRun = command({
 			);
 		}
 
-		const client = new InfisicalSDK({
-			siteUrl: url,
-		});
+		const client = new InfisicalSDK();
 
 		try {
 			await client.auth().universalAuth.login({

--- a/scripts/infisical-run.ts
+++ b/scripts/infisical-run.ts
@@ -1,0 +1,137 @@
+import { spawn } from "node:child_process";
+import { InfisicalSDK } from "@infisical/sdk";
+import { command, oneOf, option, positional, run, string } from "cmd-ts";
+
+// Helper to run a command with inherited stdio for interactive support
+function spawnWithSignal(
+	cmd: string,
+	options: { cwd: string; env: NodeJS.ProcessEnv },
+): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const child = spawn(cmd, {
+			...options,
+			shell: true,
+			stdio: "inherit",
+		});
+
+		child.on("error", reject);
+		child.on("close", (code) => resolve(code ?? 0));
+
+		// forward termination signals to the child process
+		const forward = (sig: NodeJS.Signals) => {
+			if (!child.killed) {
+				child.kill(sig);
+			}
+		};
+
+		process.on("SIGINT", () => forward("SIGINT"));
+		process.on("SIGTERM", () => forward("SIGTERM"));
+		process.on("SIGQUIT", () => forward("SIGQUIT"));
+	});
+}
+
+const infisicalRun = command({
+	name: "infisical-run",
+	args: {
+		projectId: option({
+			type: string,
+			long: "projectId",
+			description: "Infisical project identifier containing the secrets",
+		}),
+		url: option({
+			type: string,
+			long: "url",
+			description: "Base URL of the Infisical instance",
+			defaultValue: () => "https://infisical.bigmama.io",
+		}),
+		env: option({
+			type: oneOf(["dev", "stage", "prod"]),
+			long: "env",
+			short: "e",
+			description: "Infisical environment to load secrets from",
+			defaultValue: () => "dev",
+		}),
+		paths: option({
+			type: string,
+			long: "paths",
+			description: "Space-separated list of secret paths to fetch",
+			defaultValue: () => "/",
+		}),
+		dir: option({
+			type: string,
+			long: "dir",
+			description: "Working directory to run the command in",
+			defaultValue: () => ".",
+		}),
+		cmd: positional({
+			type: string,
+			displayName: "cmd",
+			description: "Command to execute with injected secrets",
+		}),
+	},
+	handler: async ({ url, env, projectId, paths, dir, cmd }) => {
+		const processedPaths = paths.split(" ").filter((path) => path !== "");
+
+		const clientId = process.env.INFISICAL_CLIENT_ID;
+		const clientSecret = process.env.INFISICAL_CLIENT_SECRET;
+
+		if (!clientId) {
+			throw new Error(
+				"INFISICAL_CLIENT_ID is required to authenticate with Infisical.",
+			);
+		}
+
+		if (!clientSecret) {
+			throw new Error(
+				"INFISICAL_CLIENT_SECRET is required to authenticate with Infisical.",
+			);
+		}
+
+		const client = new InfisicalSDK({
+			siteUrl: url,
+		});
+
+		try {
+			await client.auth().universalAuth.login({
+				clientId,
+				clientSecret,
+			});
+		} catch (error) {
+			const message =
+				error instanceof Error
+					? error.message
+					: "Unknown error during Infisical authentication";
+			throw new Error(`Infisical authentication failed: ${message}`);
+		}
+
+		console.info(`requesting secrets from ${processedPaths}`);
+		const allPathsSecrets = await Promise.all(
+			processedPaths.map((path) =>
+				client.secrets().listSecrets({
+					projectId,
+					environment: env,
+					secretPath: path,
+				}),
+			),
+		);
+
+		const secrets = allPathsSecrets.reduce<Record<string, string>>(
+			(acc, pathSecrets) => {
+				for (const secret of pathSecrets.secrets) {
+					acc[secret.secretKey] = secret.secretValue;
+				}
+				return acc;
+			},
+			{},
+		);
+		console.info(`${Object.keys(secrets).length} secrets loaded 👌`);
+		// Execute the provided command with inherited stdio for interactive support
+		const exitCode = await spawnWithSignal(cmd, {
+			env: { ...process.env, ...secrets },
+			cwd: dir,
+		});
+		process.exit(exitCode);
+	},
+});
+
+run(infisicalRun, process.argv.slice(2));

--- a/scripts/infisical-run.ts
+++ b/scripts/infisical-run.ts
@@ -42,7 +42,7 @@ const infisicalRun = command({
 			type: string,
 			long: "url",
 			description: "Base URL of the Infisical instance",
-			defaultValue: () => "https://infisical.bigmama.io",
+			defaultValue: () => "https://app.infisical.com",
 		}),
 		env: option({
 			type: oneOf(["dev", "stage", "prod"]),


### PR DESCRIPTION
## What

Implements the **secret registry** from 1hachem/lisptc#18 / 1hachem/lisptc#18: a host-provided key-value store of secrets where the **keys are readable/listable by the LLM** but the **values can only be *used* inside function calls** (e.g. as an MCP API key / HTTP header), never printed or returned as readable data.

## How

* **Opaque** `Secret` **type** (`lisp.ts`): carries its key + real value. `str()` renders it redacted as `#<secret:KEY>` via its `toString()`, covering every print path (`write`/`print`, the REPL's returned value, even nesting inside a printed list).
* **Reveal at exactly one boundary** (`mcp.ts`): `lispToJson` — the single place Lisp values become outgoing MCP JSON — unwraps `Secret` to its real value. This covers both tool-call args and ad-hoc `:headers`/`:env`.
* **Built-ins**: `(secrets)` lists available keys; `(secret "key")` returns the opaque value (errors on unknown key).
* **Host injection**: programmatic `setSecrets(record)`, `LISPTC_SECRET_*` env seeding, and `loadSecretsFromFile(path)` (parses a `.env` via the `dotenv` library). `AgentRepl` persists host-supplied secrets and re-injects them on `reset()`.

### Example (the driving use case from the issue)

```lisp
(await (load-mcp :name "linear" :url "https://mcp.linear.app/mcp"
  :headers (list (cons "Authorization" (secret "LINEAR_API_KEY")))))
```

The real key is sent in the header; the LLM only ever sees `#<secret:LINEAR_API_KEY>`.

## Tests

`test/secrets.test.ts` (9 tests): key listing, unknown-key error, redaction on print/return/nested, env seeding + override, `.env` file loading, reset re-injection, and an **end-to-end** MCP test proving a `(secret …)` argument reaches the tool as its real value while staying redacted in the REPL. Full suite: 208 passing; typecheck / lint / knip clean.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)