### PR TITLE
fix(mcp): undefine tool bindings on mcp-shutdown

### DIFF
--- a/packages/interpreter/src/mcp.ts
+++ b/packages/interpreter/src/mcp.ts
@@ -908,6 +908,10 @@ export function registerMcp(interp: Interp): void {
 		"Shut down the MCP broker worker and unload all servers.",
 		z.tuple([]),
 		() => {
+			// Undefine every installed <server>/<tool> global so stale bindings
+			// don't linger with a closure capturing a now-dead serverId.
+			for (const rec of servers.values())
+				for (const sym of rec.toolSyms) interp.undefineGlobal(sym);
 			servers.clear();
 			liveJobs.clear();
 			if (worker) {

--- a/packages/interpreter/test/mcp.test.ts
+++ b/packages/interpreter/test/mcp.test.ts
@@ -88,6 +88,30 @@ describe("MCP integration (stdio fixture)", () => {
 	});
 });
 
+describe("mcp-shutdown undefines tool bindings", () => {
+	const interp = new Interp();
+	run(interp, prelude);
+
+	it("removes <server>/<tool> globals so they error as void, not stale", () => {
+		// Load the fixture and confirm its tool symbol is bound and callable.
+		expect(
+			evalStr(
+				interp,
+				`(await (load-mcp :name "sfx" :command "node" :args (quote ("--experimental-transform-types" "${FIXTURE}"))))`,
+			),
+		).toContain("sfx/echo");
+		expect(evalStr(interp, '(sfx/echo :message "hi")')).toBe('"hi"');
+
+		// Shut down the broker: the tool binding must be gone entirely.
+		expect(evalStr(interp, "(mcp-shutdown)")).toBe("t");
+		expect(() => run(interp, "sfx/echo")).toThrow(/void variable|undefined/);
+		// And it must NOT surface as a stale "no such server" MCP error.
+		expect(() => run(interp, '(sfx/echo :message "hi")')).not.toThrow(
+			/no such server/,
+		);
+	});
+});
+
 // Build a load-mcp form for the fixture with an optional startup delay (ms).
 function loadForm(name: string, delayMs = 0): string {
 	const env =


### PR DESCRIPTION
## Bug

`mcp-shutdown` (`packages/interpreter/src/mcp.ts`) cleared the `servers` map, cleared `liveJobs`, and terminated the broker worker — but it never undefined the installed `<server>/<tool>` global symbols.

`unload-mcp` (via `doUnload`) correctly removes each server's tool symbols with `interp.undefineGlobal(sym)`, but shutdown skipped this. As a result, after `(mcp-shutdown)` symbols like `playwright/browser_navigate` stayed bound and callable, yet their closures captured a now-dead `serverId`. Calling them threw a confusing `MCP error: no such server: <id>` instead of the correct `void variable` error.

## Fix

Before `servers.clear()`, iterate every server in the `servers` map and call `interp.undefineGlobal(sym)` for each `sym` in that server's `toolSyms`. Minimal change, matching the style of `doUnload`.

## Test

Added a regression test in `packages/interpreter/test/mcp.test.ts` (real worker_threads broker + stdio fixture) that:
- loads a fixture MCP server and confirms `sfx/echo` is bound and callable,
- calls `(mcp-shutdown)`,
- asserts referencing the tool symbol now errors as an unbound/void variable, and NOT as a stale "no such server" MCP error.

All 24 tests in `test/mcp.test.ts` pass; typecheck and `biome ci` lint are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)