### PR TITLE
fix(mcp): validate await timeout before finalized short-circuit

### DIFF
--- a/packages/interpreter/src/mcp.ts
+++ b/packages/interpreter/src/mcp.ts
@@ -556,8 +556,11 @@ export function registerMcp(interp: Interp): void {
 			const args = listToArray(rest);
 			const job = args[0];
 			if (!(job instanceof Job)) throw new EvalException("not a job", job);
+			// Validate the timeout before short-circuiting so an invalid timeout is
+			// rejected regardless of whether the job has already finalized.
+			const timeout = parseTimeout(args[1]);
 			if (job.finalized) return job.cached;
-			return collect(job, mcpAwait(job.jobId, parseTimeout(args[1])));
+			return collect(job, mcpAwait(job.jobId, timeout));
 		},
 	);
 

--- a/packages/interpreter/test/mcp.test.ts
+++ b/packages/interpreter/test/mcp.test.ts
@@ -128,6 +128,12 @@ describe("async MCP jobs", () => {
 		expect(evalStr(interp, "(await j)")).toContain("afx/echo");
 	});
 
+	it("rejects an invalid timeout even on a finalized job", () => {
+		// `j` is already finalized (awaited above); an invalid timeout must still
+		// be rejected, matching the behavior on a fresh job.
+		expect(() => run(interp, "(await j -5)")).toThrow(/invalid await timeout/);
+	});
+
 	it("await honors a timeout and leaves the job awaitable", () => {
 		evalStr(interp, `(setq slow ${loadForm("slowfx", 2000)})`);
 		expect(() => run(interp, "(await slow 1)")).toThrow(/timed out/);


### PR DESCRIPTION
## Problem

The `await` built-in (`packages/interpreter/src/mcp.ts`) short-circuited on `job.finalized` **before** validating the optional timeout argument:

```ts
if (job.finalized) return job.cached;
return collect(job, mcpAwait(job.jobId, parseTimeout(args[1])));
```

`parseTimeout` throws `invalid await timeout` on non-finite or negative values. Because it only ran on the non-finalized path, `(await j -5)` threw on a fresh job but was **silently accepted** on an already-finalized job. Inconsistent.

## Fix

Compute and validate the timeout right after the `instanceof Job` check, then reuse it, so an invalid timeout is rejected regardless of job state:

```ts
const timeout = parseTimeout(args[1]);
if (job.finalized) return job.cached;
return collect(job, mcpAwait(job.jobId, timeout));
```

Behavior for valid timeouts is unchanged.

## Test

Adds a regression test in `test/mcp.test.ts` (real broker + stdio fixture): after `j` has been awaited/finalized, `(await j -5)` now throws `invalid await timeout`, matching the fresh-job behavior. All 24 mcp tests pass; typecheck and lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)