### PR TITLE
feat(mcp): show enum allowed values in mcp-doc

### DIFF
--- a/packages/interpreter/src/mcp.ts
+++ b/packages/interpreter/src/mcp.ts
@@ -963,7 +963,10 @@ function renderDoc(name: string, tool: Tool): string {
 			const req = required.has(key) ? " (required)" : "";
 			const type = spec.type ? `:${spec.type}` : "";
 			const desc = spec.description ? ` — ${spec.description}` : "";
-			lines.push(`  ${key}${type}${req}${desc}`);
+			const allowed = spec.enum?.length
+				? ` (one of ${JSON.stringify(spec.enum)})`
+				: "";
+			lines.push(`  ${key}${type}${req}${allowed}${desc}`);
 		}
 	}
 	return lines.join("\n");

--- a/packages/interpreter/test/fixture-enum-mcp-server.ts
+++ b/packages/interpreter/test/fixture-enum-mcp-server.ts
@@ -1,0 +1,29 @@
+/*
+ * Minimal stdio MCP server used by the test suite to exercise enum rendering.
+ * Exposes one tool, `render`, whose required `format` argument is constrained to
+ * an enum (["png", "jpeg"]) so tests can assert that mcp-doc surfaces the
+ * allowed values.
+ *
+ * Run manually:
+ *   node --experimental-transform-types test/fixture-enum-mcp-server.ts
+ */
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { z } from "zod";
+
+const server = new McpServer({ name: "fixture-enum", version: "1.0.0" });
+
+server.registerTool(
+	"render",
+	{
+		description: "Render in the requested format.",
+		inputSchema: {
+			format: z.enum(["png", "jpeg"]).describe("the output image format"),
+		},
+	},
+	async ({ format }) => ({
+		content: [{ type: "text", text: String(format) }],
+	}),
+);
+
+await server.connect(new StdioServerTransport());

--- a/packages/interpreter/test/mcp.test.ts
+++ b/packages/interpreter/test/mcp.test.ts
@@ -13,6 +13,9 @@ const FIXTURE = fileURLToPath(
 const EMPTY_FIXTURE = fileURLToPath(
 	new URL("./fixture-empty-mcp-server.ts", import.meta.url),
 );
+const ENUM_FIXTURE = fileURLToPath(
+	new URL("./fixture-enum-mcp-server.ts", import.meta.url),
+);
 
 describe("self-evaluating keywords", () => {
 	const interp = new Interp();
@@ -109,6 +112,27 @@ describe("mcp-shutdown undefines tool bindings", () => {
 		expect(() => run(interp, '(sfx/echo :message "hi")')).not.toThrow(
 			/no such server/,
 		);
+	});
+});
+
+describe("mcp-doc enum rendering (stdio fixture)", () => {
+	const interp = new Interp();
+	run(interp, prelude);
+
+	afterAll(() => {
+		run(interp, "(mcp-shutdown)");
+	});
+
+	it("surfaces an argument's enum allowed values", () => {
+		evalStr(
+			interp,
+			`(await (load-mcp :name "en" :command "node" :args (quote ("--experimental-transform-types" "${ENUM_FIXTURE}"))))`,
+		);
+		const doc = evalStr(interp, "(mcp-doc 'en/render)");
+		expect(doc).toContain("format");
+		expect(doc).toContain("one of");
+		expect(doc).toContain("png");
+		expect(doc).toContain("jpeg");
 	});
 });
 


### PR DESCRIPTION
## The gap
`renderDoc()` in `packages/interpreter/src/mcp.ts` (backing the `mcp-doc` built-in) rendered each argument line as `  <key><:type><(required)> — <description>` but omitted any JSON-Schema `enum` constraint. The `validate()` function already enforces enums and even lists the allowed values in its error message, so a caller could only discover the allowed values by triggering a failed call.

## The fix
In `renderDoc()`, when an argument's `spec.enum` is present and non-empty, append the allowed values to that argument's line as ` (one of <JSON>)`, using `JSON.stringify(spec.enum)` to match `validate()`'s existing formatting (`must be one of ${JSON.stringify(spec.enum)}`). `list-tools` output shape is unchanged.

## Test / fixture choice
The shared `fixture-mcp-server.ts` (echo tool) has no enum argument. Rather than adding an enum arg to it and risking the existing echo-tool tests, I added a small dedicated fixture `test/fixture-enum-mcp-server.ts` whose one tool (`render`) has an enum-constrained `format` argument (`["png","jpeg"]`). A new test loads it and asserts `(mcp-doc "en/render")` output surfaces the allowed values.

## Verification
- `pnpm --filter @repo/interpreter exec vitest run test/mcp.test.ts` — 24 passed
- `pnpm --filter @repo/interpreter typecheck` — pass
- `pnpm lint` — pass; `pnpm knip` — clean (new fixture referenced by the test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)