### PR TITLE
docs(examples): split showcase into per-feature files

### DIFF
--- a/examples/basics.ptc
+++ b/examples/basics.ptc
@@ -1,0 +1,74 @@
+;;; =====================================================================
+;;; lisptc — basics: atoms, arithmetic, lists, control flow
+;;;
+;;; Run me:
+;;;   pnpm --filter @repo/interpreter exec \
+;;;     node --experimental-transform-types src/lisp.ts ../../examples/basics.ptc
+;;; =====================================================================
+
+(princ "=== 1. atoms, arithmetic & big numbers ===")
+(terpri)
+
+;; numbers are number | bigint; arithmetic promotes automatically
+(print (+ 1 2 3 4 5))
+; => 15
+(print (* 6 7))
+; => 42
+(print (/ 22 7))
+(print (- 10 3 2))
+; => 5
+;; arithmetic promotes to bigint automatically — exact, no overflow
+(print (* 1000000000000 1000000000000))
+; => 1000000000000000000000000  (bigint, exact)
+(print (< 1 2))
+; => t
+
+(princ "=== 2. lists & cons cells ===")
+(terpri)
+
+(setq xs (list 1 2 3 4 5))
+(print xs)
+(print (car xs))
+; => 1
+(print (cdr xs))
+; => (2 3 4 5)
+(print (cadr xs))
+; => 2
+(print (append xs (list 6 7)))
+; => (1 2 3 4 5 6 7)
+(print (nreverse (list 1 2 3)))
+; => (3 2 1)
+
+(princ "=== 3. control flow: cond / when / let / while / dolist ===")
+(terpri)
+
+(defun classify (n) (cond ((< n 0) 'negative) ((= n 0) 'zero) (t 'positive)))
+(print (mapcar classify (list -3 0 7)))
+; => (negative zero positive)
+
+(let ((a 3) (b 4)) (print (+ (* a a) (* b b))))
+; => 25
+
+;; imperative loop with mutation
+(setq sum 0)
+(dolist (x (list 10 20 30)) (setq sum (+ sum x)))
+(print sum)
+; => 60
+
+(setq i 0)
+(setq acc nil)
+(while (< i 5) (setq acc (cons i acc)) (setq i (+ i 1)))
+(print (nreverse acc))
+; => (0 1 2 3 4)
+
+(princ "=== 4. association lists (symbolic data) ===")
+(terpri)
+
+(setq db '((alice . 30) (bob . 25) (carol . 35)))
+(print (assoc 'bob db))
+; => (bob . 25)
+(print (cdr (assoc 'carol db)))
+; => 35
+
+(princ "=== done ===")
+(terpri)

--- a/examples/linear.ptc
+++ b/examples/linear.ptc
@@ -1,0 +1,38 @@
+;;; =====================================================================
+;;; lisptc — Linear MCP (issue tracker over OAuth)
+;;;
+;;; The `linear` server is bundled in the toolkit as an OAuth HTTP
+;;; server. First load returns an authorization link:
+;;;   1. (load-mcp "linear")  -> approve the printed link
+;;;   2. (mcp-authorize "linear" "<code>")
+;;;   3. (await (load-mcp "linear"))  -> tools installed
+;;; =====================================================================
+
+(princ "=== authorize & load ===")
+(terpri)
+
+;; Kick off the OAuth flow — prints an authorization URL.
+(load-mcp "linear")
+
+;; After approving in the browser, paste the code back:
+;; (mcp-authorize "linear" "<code-from-browser>")
+
+;; Then connect and install the linear/<tool> bindings.
+(await (load-mcp "linear"))
+
+(print (list-mcps))
+(print (search-tools "list issues"))
+
+(princ "=== query issues ===")
+(terpri)
+
+;; Tools are ordinary bindings called with keyword syntax.
+(print (linear/list-issues :query "auth bug"))
+(print (linear/list-teams))
+
+(princ "=== teardown ===")
+(terpri)
+(unload-mcp "linear")
+
+(princ "=== done ===")
+(terpri)

--- a/examples/macros-and-functions.ptc
+++ b/examples/macros-and-functions.ptc
@@ -1,0 +1,56 @@
+;;; =====================================================================
+;;; lisptc — function definitions, closures, recursion & macros
+;;;
+;;; Run me:
+;;;   pnpm --filter @repo/interpreter exec \
+;;;     node --experimental-transform-types src/lisp.ts ../../examples/macros-and-functions.ptc
+;;; =====================================================================
+
+(princ "=== 1. lambdas, closures & higher order ===")
+(terpri)
+
+;; a closure capturing `n`
+(defun adder (n) (lambda (x) (+ x n)))
+(setq add10 (adder 10))
+(print (add10 5))
+; => 15
+(print (mapcar add10 (list 1 2 3)))
+; => (11 12 13)
+
+;; fold via recursion
+(defun reduce (f acc lst)
+  (if (null lst) acc
+      (reduce f (f acc (car lst)) (cdr lst))))
+(print (reduce + 0 (list 1 2 3 4 5)))
+; => 15
+
+(princ "=== 2. recursion ===")
+(terpri)
+
+(defun fact (n) (if (<= n 1) 1 (* n (fact (- n 1)))))
+(print (fact 20))
+; => 2432902008176640000
+(print (fact 30))
+; => big, exact bigint
+(defun fib (n) (if (< n 2) n (+ (fib (- n 1)) (fib (- n 2)))))
+(print (fib 15))
+; => 610
+
+(princ "=== 3. macros & quasiquotation ===")
+(terpri)
+
+;; define our own control macro with `,` unquote and `,@` splice
+(defmacro unless (test &rest body) `(cond ((not ,test) ,@body)))
+(print (unless nil 'ran 'ok))
+; => ok
+
+;; a macro that builds code at expansion time
+(defmacro swap (a b) `(let ((tmp ,a)) (setq ,a ,b) (setq ,b tmp)))
+(setq p 1)
+(setq q 2)
+(swap p q)
+(print (list p q))
+; => (2 1)
+
+(princ "=== done ===")
+(terpri)

--- a/examples/mcp.ptc
+++ b/examples/mcp.ptc
@@ -1,0 +1,77 @@
+;;; =====================================================================
+;;; lisptc — MCP support (generic features)
+;;;
+;;; MCP built-ins installed on every Interp:
+;;;   load-mcp / unload-mcp / list-mcps / list-toolkit / list-tools
+;;;   mcp-doc / search-tools / search-mcps / mcp-shutdown
+;;;   await / await-all / await-any / job-status / jobs / cancel
+;;;
+;;; This file uses the repo's bundled filesystem server (`fs`) so it
+;;; runs with no OAuth / credentials. See playwright.ptc and linear.ptc
+;;; for server-specific demos.
+;;; =====================================================================
+
+(princ "=== 1. discover the bundled toolkit ===")
+(terpri)
+
+;; What servers ship ready-to-use?
+(print (list-toolkit))
+;; Fuzzy search across predefined servers, ranked best-first.
+(print (search-mcps "browser"))
+
+(princ "=== 2. load a server (async job + await) ===")
+(terpri)
+
+;; `load-mcp` returns a Job handle immediately; `await` blocks until the
+;; connect settles and installs the <server>/<tool> bindings.
+(await (load-mcp "fs"))
+
+;; What servers are loaded, and how many tools each has?
+(print (list-mcps))
+; => ((fs :loaded N))
+
+;; Enumerate one server's tools: (symbol param-count doc)
+(print (list-tools "fs"))
+
+(princ "=== 3. tool docs & search ===")
+(terpri)
+
+;; Full documentation for one tool, including per-parameter docs.
+(princ (mcp-doc 'fs/read_file))
+(terpri)
+
+;; Fuzzy search across all *loaded* tools, ranked best-first.
+(print (search-tools "write a file"))
+
+(princ "=== 4. call a tool ===")
+(terpri)
+
+;; Each tool is an ordinary global binding named <server>/<tool>,
+;; called with native keyword syntax. The synchronous interpreter
+;; blocks on the async broker under the hood.
+;; NOTE: the fs server is sandboxed to its working directory, so use a
+;; relative path (writing outside the cwd is denied).
+(fs/write_file :path "lisptc-mcp-demo.txt" :content "hello from lisptc")
+(princ (fs/read_file :path "lisptc-mcp-demo.txt"))
+(terpri)
+
+(princ "=== 5. async jobs without an explicit await ===")
+(terpri)
+
+;; A load-mcp job settles in the background; its tools appear
+;; automatically between evals. `jobs` / `job-status` poll without
+;; blocking.
+(setq j (load-mcp "fs"))
+(print (job-status j))
+; => :pending or :done
+(print (jobs))
+
+(princ "=== 6. teardown ===")
+(terpri)
+
+;; Unload releases the tool bindings; shutdown tears down the broker.
+(unload-mcp "fs")
+(mcp-shutdown)
+
+(princ "=== done ===")
+(terpri)

--- a/examples/playwright.ptc
+++ b/examples/playwright.ptc
@@ -1,0 +1,35 @@
+;;; =====================================================================
+;;; lisptc — Playwright MCP (drive a real Chromium browser)
+;;;
+;;; The `playwright` server is bundled in the toolkit (stdio, no auth).
+;;; It can navigate, click, type, snapshot the accessibility tree,
+;;; screenshot, and read network requests.
+;;; =====================================================================
+
+(princ "=== load the browser server ===")
+(terpri)
+
+;; Boots @playwright/mcp and installs the playwright/<tool> bindings.
+(await (load-mcp "playwright"))
+
+;; See what it exposes.
+(print (list-tools "playwright"))
+(print (search-tools "navigate"))
+
+(princ "=== drive a page ===")
+(terpri)
+
+;; Navigate, then snapshot the accessibility tree of the loaded page.
+(playwright/browser_navigate :url "https://hyko.ai")
+(princ (playwright/browser_snapshot))
+(terpri)
+
+;; Navigate somewhere else.
+(playwright/browser_navigate :url "https://yourscrib.ai")
+
+(princ "=== teardown ===")
+(terpri)
+(unload-mcp "playwright")
+
+(princ "=== done ===")
+(terpri)


### PR DESCRIPTION
## What

Splits the monolithic `examples/sample.ptc` into focused, easy-to-test files:

- `basics.ptc` — atoms, arithmetic & bigints, lists/cons, control flow, alists
- `macros-and-functions.ptc` — closures, higher-order, recursion, macros & quasiquote
- `mcp.ptc` — generic MCP features via the bundled (no-auth) `fs` server
- `playwright.ptc` — driving a real Chromium browser
- `linear.ptc` — OAuth issue-tracker flow (authorize → load → query)

## Verification

- `basics.ptc` and `macros-and-functions.ptc` execute clean through `run()`.
- All five files pass `checkSyntax`.
- `mcp.ptc` mechanics smoke-tested live: `list-toolkit`, `load-mcp "fs"` (14 tools), `write_file`/`read_file` round-trip.
- Corrected stale snippets from `sample.ptc`: `expt` and chained `<` are not implemented; the `fs` server sandboxes writes to its cwd.

Note: the original `examples/sample.ptc` is left in place (not deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)