### PR TITLE
feat(repl): add a host tool RPC bridge

### DIFF
--- a/packages/repl/package.json
+++ b/packages/repl/package.json
@@ -6,6 +6,7 @@
   "exports": {
     "./repl.ts": "./src/repl.ts",
     "./session-server.ts": "./src/session-server.ts",
+    "./host-bridge.ts": "./src/host-bridge.ts",
     "./cli.ts": "./src/cli.ts",
     "./package.json": "./package.json"
   },

--- a/packages/repl/src/cli.ts
+++ b/packages/repl/src/cli.ts
@@ -7,6 +7,14 @@
  */
 
 import {
+	existsSync,
+	readFileSync,
+	renameSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { join } from "node:path";
+import {
 	EndOfFile,
 	EvalException,
 	Interp,
@@ -17,6 +25,7 @@ import {
 	setWriter,
 	str,
 } from "@repo/interpreter/lisp.ts";
+import { type HostToolSpec, installHostTools } from "./host-bridge.ts";
 import { type Repl, seedSecretsFromEnvFile } from "./repl.ts";
 import {
 	connectOrSpawn,
@@ -39,7 +48,7 @@ class InteractiveRepl implements Repl {
 	private currentInterp: Interp;
 	private readonly stdInTokens: Reader = new Reader();
 
-	constructor() {
+	constructor(private readonly loadEnvSecrets = true) {
 		this.currentInterp = this.freshInterp();
 	}
 
@@ -50,7 +59,7 @@ class InteractiveRepl implements Repl {
 	private freshInterp(): Interp {
 		const interp = new Interp();
 		run(interp, prelude);
-		seedSecretsFromEnvFile(interp);
+		if (this.loadEnvSecrets) seedSecretsFromEnvFile(interp);
 		return interp;
 	}
 
@@ -166,6 +175,49 @@ async function main(): Promise<void> {
 				? `killed session${name ? ` "${name}"` : ""}`
 				: `no session running${name ? ` for "${name}"` : ""}`,
 		);
+		return;
+	}
+
+	if (process.argv[2] === "--host-rpc") {
+		const fileName = process.argv[3];
+		const rpcDir = process.env.LISPTC_HOST_RPC_DIR;
+		const token = process.env.LISPTC_HOST_RPC_TOKEN;
+		if (!fileName || !rpcDir || !token)
+			throw new Error(
+				"--host-rpc requires a program file, LISPTC_HOST_RPC_DIR, and LISPTC_HOST_RPC_TOKEN",
+			);
+		let sequence = 0;
+		const repl = new InteractiveRepl(false);
+		const tools = JSON.parse(
+			process.env.LISPTC_HOST_RPC_TOOLS ?? "[]",
+		) as HostToolSpec[];
+		installHostTools(repl.interp, tools, (tool, args) => {
+			sequence += 1;
+			const seq = String(sequence).padStart(6, "0");
+			const request = join(rpcDir, `req_${seq}`);
+			const response = join(rpcDir, `res_${seq}`);
+			writeFileSync(
+				`${request}.tmp`,
+				JSON.stringify({ tool, args, seq: sequence, token }),
+				"utf8",
+			);
+			renameSync(`${request}.tmp`, request);
+			const deadline = Date.now() + 300_000;
+			while (!existsSync(response)) {
+				if (Date.now() > deadline)
+					throw new Error(`Host RPC timeout calling ${tool}`);
+				Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 10);
+			}
+			const raw = JSON.parse(readFileSync(response, "utf8")) as unknown;
+			unlinkSync(response);
+			if (typeof raw !== "string") return raw;
+			try {
+				return JSON.parse(raw) as unknown;
+			} catch {
+				return raw;
+			}
+		});
+		write(`${str(run(repl.interp, readFileSync(fileName, "utf8")))}\n`);
 		return;
 	}
 

--- a/packages/repl/src/host-bridge.ts
+++ b/packages/repl/src/host-bridge.ts
@@ -1,0 +1,111 @@
+/** Host adapter for exposing an explicitly supplied set of tools to Lisptc. */
+import {
+	Cell,
+	type Interp,
+	type List,
+	newSym,
+	Sym,
+} from "@repo/interpreter/lisp.ts";
+
+export type HostCall = (tool: string, args: Record<string, unknown>) => unknown;
+
+function arrayToList(values: unknown[]): List {
+	let out: List = null;
+	for (let i = values.length - 1; i >= 0; i--) out = new Cell(values[i], out);
+	return out;
+}
+
+function jsonToLisp(value: unknown): unknown {
+	if (value === null || value === undefined || value === false) return null;
+	if (value === true || typeof value === "string" || typeof value === "number")
+		return value;
+	if (Array.isArray(value)) return arrayToList(value.map(jsonToLisp));
+	if (typeof value === "object") {
+		return arrayToList(
+			Object.entries(value as Record<string, unknown>).map(
+				([key, item]) => new Cell(key, jsonToLisp(item)),
+			),
+		);
+	}
+	return String(value);
+}
+
+function listToArray(value: List): unknown[] {
+	const result: unknown[] = [];
+	for (let item = value; item !== null; item = item.cdr as List)
+		result.push(item.car);
+	return result;
+}
+
+function lispToJson(value: unknown): unknown {
+	if (
+		value === null ||
+		value === true ||
+		typeof value === "string" ||
+		typeof value === "number" ||
+		typeof value === "boolean"
+	)
+		return value;
+	if (typeof value === "bigint") return Number(value);
+	if (value instanceof Sym) return value.name;
+	if (value instanceof Cell) {
+		const items = listToArray(value);
+		const isAlist = items.every(
+			(item) =>
+				item instanceof Cell &&
+				(typeof item.car === "string" || item.car instanceof Sym),
+		);
+		if (isAlist) {
+			const object: Record<string, unknown> = {};
+			for (const item of items as Cell[]) {
+				const key = item.car instanceof Sym ? item.car.name : String(item.car);
+				object[key] = lispToJson(item.cdr);
+			}
+			return object;
+		}
+		return items.map(lispToJson);
+	}
+	return String(value);
+}
+
+export interface HostToolSpec {
+	hostName: string;
+	lispName?: string;
+	parameters: string[];
+	defaults?: unknown[];
+	parameterShapes?: Partial<Record<string, "array">>;
+}
+
+export function installHostTools(
+	interp: Interp,
+	toolSpecs: HostToolSpec[],
+	call: HostCall,
+): void {
+	for (const spec of toolSpecs) {
+		if (!/^[A-Za-z0-9_-]+$/.test(spec.hostName))
+			throw new Error(`Invalid host tool name: ${spec.hostName}`);
+		const lispName = spec.lispName ?? spec.hostName.replaceAll("_", "-");
+		if (!/^[A-Za-z0-9_+*/<>=!?-]+$/.test(lispName))
+			throw new Error(`Invalid Lisp tool name: ${lispName}`);
+		const fn = interp.makeBuiltIn(lispName, -1, (frame) => {
+			const supplied = listToArray(frame[0] as List);
+			const args: Record<string, unknown> = {};
+			for (let i = 0; i < spec.parameters.length; i++) {
+				const value = i < supplied.length ? supplied[i] : spec.defaults?.[i];
+				const parameter = spec.parameters[i];
+				if (value !== undefined)
+					args[parameter] =
+						value === null &&
+						i < supplied.length &&
+						spec.parameterShapes?.[parameter] === "array"
+							? []
+							: lispToJson(value);
+			}
+			return jsonToLisp(call(spec.hostName, args));
+		});
+		interp.defineGlobal(newSym(lispName), fn, {
+			signature: `(${lispName} ...)`,
+			doc: `Call the host-authorized ${spec.hostName} tool.`,
+		});
+	}
+}

--- a/packages/repl/test/host-bridge.test.ts
+++ b/packages/repl/test/host-bridge.test.ts
@@ -1,0 +1,88 @@
+import { Interp, prelude, run, str } from "@repo/interpreter/lisp.ts";
+import { describe, expect, it } from "vitest";
+import { type HostToolSpec, installHostTools } from "../src/host-bridge.ts";
+
+const TOOL_SPECS: HostToolSpec[] = [
+	{
+		hostName: "read_file",
+		parameters: ["path", "offset", "limit"],
+		defaults: [undefined, 1, 2000],
+	},
+	{
+		hostName: "search_files",
+		parameters: ["pattern", "target", "path"],
+		defaults: [undefined, "content", "."],
+	},
+	{
+		hostName: "fetch_urls",
+		lispName: "fetch-urls",
+		parameters: ["urls", "limit"],
+		defaults: [undefined, null],
+		parameterShapes: { urls: "array" },
+	},
+	{
+		hostName: "save_data",
+		parameters: ["path", "content"],
+		defaults: [undefined, undefined],
+	},
+];
+
+describe("host bridge", () => {
+	it("composes two host tools and returns the reduced value", () => {
+		const interp = new Interp();
+		run(interp, prelude);
+		const calls: string[] = [];
+		installHostTools(interp, TOOL_SPECS.slice(0, 2), (tool, args) => {
+			calls.push(tool);
+			if (tool === "read_file")
+				return { content: `contents:${String(args.path)}`, total_lines: 1 };
+			return { matches: [{ file: "a.ts" }, { file: "b.ts" }] };
+		});
+
+		const result = run(
+			interp,
+			`(let ((f (read-file "notes.txt"))
+			       (m (search-files "needle" "content" ".")))
+			   (list (cdr (assoc "content" f))
+			         (length (cdr (assoc "matches" m)))))`,
+		);
+
+		expect(str(result)).toBe('("contents:notes.txt" 2)');
+		expect(calls).toEqual(["read_file", "search_files"]);
+	});
+
+	it("converts Lisp collections to JSON arrays and objects", () => {
+		const interp = new Interp();
+		run(interp, prelude);
+		const seen: Record<string, unknown>[] = [];
+		installHostTools(interp, TOOL_SPECS.slice(2), (_tool, args) => {
+			seen.push(args);
+			return { ok: true };
+		});
+
+		run(interp, "(fetch-urls nil)");
+		run(interp, '(fetch-urls (list "https://a" "https://b"))');
+		run(
+			interp,
+			'(save-data "out.json" (list (cons "nested" (list 1 2)) (cons "enabled" t)))',
+		);
+
+		expect(seen[0]).toEqual({ urls: [], limit: null });
+		expect(seen[1]?.urls).toEqual(["https://a", "https://b"]);
+		expect(seen[2]?.content).toEqual({ nested: [1, 2], enabled: true });
+	});
+
+	it("installs only supplied tools and rejects unsafe names", () => {
+		const interp = new Interp();
+		installHostTools(interp, [TOOL_SPECS[0]], () => null);
+		expect(interp.globalNames()).toContain("read-file");
+		expect(interp.globalNames()).not.toContain("search-files");
+		expect(() =>
+			installHostTools(
+				interp,
+				[{ hostName: "unsafe name", parameters: [] }],
+				() => null,
+			),
+		).toThrow("Invalid host tool name");
+	});
+});


### PR DESCRIPTION
## Summary

Adds an opt-in `--host-rpc` mode to the Lisptc REPL CLI so an authorized host can expose a narrow, explicitly described set of tools as ordinary Lisp functions.

- accepts host-provided tool names, Lisp names, positional parameters, defaults, and collection shapes
- maps Lisp positional arguments to host RPC objects
- converts JSON objects/arrays to Lisp alists/lists and back
- performs synchronous request/response exchange through a host-owned file-RPC directory
- starts this mode without seeding `.env` secrets into the interpreter
- preserves the existing interactive and session-server CLI behavior

Authorization, policy, approvals, budgets, and dispatch remain host-owned; this PR only supplies the generic Lisptc-side adapter and local RPC CLI mode.

## Security boundary

`--host-rpc` requires a program path, private RPC directory, and per-run token supplied by the host. The host also provides the explicit tool specifications; no tools are installed implicitly. Host and Lisp tool names are validated before installation. The mode is fresh per invocation and does not load Lisptc `.env` secrets.

## Validation

- `pnpm --filter @repo/repl test` — 28 tests passed
- `pnpm --filter @repo/repl typecheck` — passed
- Biome check on the four changed files — passed
- generic file-RPC smoke — two host calls composed; process exited cleanly
- `git diff --check` — passed

## Grammar note

The existing `packages/interpreter/src/lisptc.gbnf` remains the right provider-side syntax constraint when a model provider supports grammar mode. No parser or grammar change is needed for this host bridge.
