### PR TITLE
 collapse the sidebar by default, remember both rails in cookies

### DIFF
--- a/apps/app/src/lib/prefs.ts
+++ b/apps/app/src/lib/prefs.ts
@@ -1,0 +1,31 @@
+import { createIsomorphicFn } from "@tanstack/react-start";
+import { getCookie } from "@tanstack/react-start/server";
+
+const YEAR_SECONDS = 60 * 60 * 24 * 365;
+
+export const SIDEBAR_COOKIE = "ui.sidebar";
+export const PANEL_COOKIE = "ui.panel";
+
+// Read on both sides so SSR and the first client render agree: the server sees
+// the request's Cookie header, the browser its own jar.
+const readCookie = createIsomorphicFn()
+	.server((name: string) => getCookie(name))
+	.client((name: string) =>
+		document.cookie
+			.split("; ")
+			.find((pair) => pair.startsWith(`${name}=`))
+			?.slice(name.length + 1),
+	);
+
+export function readBoolPref(name: string, fallback: boolean) {
+	const raw = readCookie(name);
+	if (raw === "true") return true;
+	if (raw === "false") return false;
+	return fallback;
+}
+
+export function writeBoolPref(name: string, value: boolean) {
+	if (typeof document === "undefined") return;
+	// biome-ignore lint/suspicious/noDocumentCookie: the suggested Cookie Store API is still missing from Safari and Firefox.
+	document.cookie = `${name}=${value}; path=/; max-age=${YEAR_SECONDS}; samesite=lax`;
+}

--- a/apps/app/src/lib/ui.tsx
+++ b/apps/app/src/lib/ui.tsx
@@ -1,4 +1,16 @@
-import { createContext, useContext, useMemo, useState } from "react";
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useMemo,
+	useState,
+} from "react";
+import {
+	PANEL_COOKIE,
+	readBoolPref,
+	SIDEBAR_COOKIE,
+	writeBoolPref,
+} from "./prefs.ts";
 
 interface UIContextValue {
 	leftOpen: boolean;
@@ -12,19 +24,33 @@ interface UIContextValue {
 const UIContext = createContext<UIContextValue | null>(null);
 
 export function UIProvider({ children }: { children: React.ReactNode }) {
-	const [leftOpen, setLeftOpen] = useState(true);
-	const [rightOpen, setRightOpen] = useState(false);
+	const [leftOpen, setLeft] = useState(() =>
+		readBoolPref(SIDEBAR_COOKIE, false),
+	);
+	const [rightOpen, setRight] = useState(() =>
+		readBoolPref(PANEL_COOKIE, false),
+	);
+
+	const setLeftOpen = useCallback((open: boolean) => {
+		setLeft(open);
+		writeBoolPref(SIDEBAR_COOKIE, open);
+	}, []);
+
+	const setRightOpen = useCallback((open: boolean) => {
+		setRight(open);
+		writeBoolPref(PANEL_COOKIE, open);
+	}, []);
 
 	const value = useMemo<UIContextValue>(
 		() => ({
 			leftOpen,
 			setLeftOpen,
-			toggleLeft: () => setLeftOpen((o) => !o),
+			toggleLeft: () => setLeftOpen(!leftOpen),
 			rightOpen,
 			setRightOpen,
-			toggleRight: () => setRightOpen((o) => !o),
+			toggleRight: () => setRightOpen(!rightOpen),
 		}),
-		[leftOpen, rightOpen],
+		[leftOpen, rightOpen, setLeftOpen, setRightOpen],
 	);
 
 	return <UIContext.Provider value={value}>{children}</UIContext.Provider>;

--- a/packages/ui/src/components/ui/sidebar.tsx
+++ b/packages/ui/src/components/ui/sidebar.tsx
@@ -77,12 +77,13 @@ function SidebarProvider({
     (value: boolean | ((value: boolean) => boolean)) => {
       const openState = typeof value === "function" ? value(open) : value
       if (setOpenProp) {
+        // Controlled: the owner persists it. Writing here too would have every
+        // provider on the page clobber the one shared cookie name.
         setOpenProp(openState)
-      } else {
-        _setOpen(openState)
+        return
       }
 
-      // This sets the cookie to keep the sidebar state.
+      _setOpen(openState)
       document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`
     },
     [setOpenProp, open]


### PR DESCRIPTION
The sidebar and the panel are now both closed on a first visit, and every toggle writes `ui.sidebar` / `ui.panel` for a year.

The read is isomorphic: `getCookie` off the request header during SSR, `document.cookie` in the browser. Both sides see the same value on the first render, so the rail doesn't flip after hydration.

`SidebarProvider` no longer writes its own `sidebar_state` cookie when it is controlled -- the shell mounts two of them and they were clobbering that one shared name. Uncontrolled use is unchanged.