### PR TITLE
fix(app): hold the reader's place when a turn is sent

### DIFF
--- a/apps/app/src/components/chat-view.tsx
+++ b/apps/app/src/components/chat-view.tsx
@@ -1,4 +1,9 @@
-import { Conversation, ConversationContent } from "@repo/ui";
+import {
+	Conversation,
+	ConversationContent,
+	useStickToBottomContext,
+} from "@repo/ui";
+import { useEffect } from "react";
 import {
 	type ChatMessage,
 	isGreetingMessage,
@@ -30,11 +35,47 @@ function ToolMessage({ message }: { message: ChatMessage }) {
 	);
 }
 
+/**
+ * Sending is a jump to the bottom: the turn just typed, and the reply about to
+ * land under it, are what the sender wants in view. Instant, not animated —
+ * being carried down through the whole transcript is the thing worth avoiding.
+ */
+function StickOnSend({ turn }: { turn: string | undefined }) {
+	const { scrollToBottom } = useStickToBottomContext();
+	useEffect(() => {
+		if (turn) scrollToBottom("instant");
+	}, [turn, scrollToBottom]);
+	return null;
+}
+
+/**
+ * The way back down, for a reader who has travelled up the transcript. It rides
+ * at the foot of the conversation — directly above the composer — and shows
+ * itself only once the view has left the bottom, which the container reports
+ * with a 70px grace so it never flickers in on the last line.
+ */
+function ScrollToLatest() {
+	const { isAtBottom, scrollToBottom } = useStickToBottomContext();
+	if (isAtBottom) return null;
+	return (
+		<button
+			type="button"
+			onClick={() => scrollToBottom("instant")}
+			className="absolute bottom-1 left-1/2 flex -translate-x-1/2 items-center gap-[7px] rounded-none bg-bg2 px-[9px] py-px text-[11.5px] text-fg hover:brightness-125"
+		>
+			<span>latest</span>
+			<span className="text-dim">▼</span>
+		</button>
+	);
+}
+
 export function ChatView() {
 	const { messages, error } = useChatSession();
+	const lastSent = messages.filter(isUser).at(-1)?.id;
 
 	return (
 		<Conversation className="min-h-0 flex-1 px-8 pt-6">
+			<StickOnSend turn={lastSent} />
 			<ConversationContent className="mx-auto w-full max-w-[680px] gap-5 pb-3">
 				{/*
 				 * The opening line is a turn like any other, so it stays put once the
@@ -95,7 +136,16 @@ export function ChatView() {
 						{error}
 					</div>
 				)}
+				{/*
+				 * Room to scroll past the last turn: the tail of the conversation comes
+				 * to rest in the upper three quarters of the screen rather than hard
+				 * against the composer. It is a quarter of the viewport of real
+				 * scrollable height, so a short conversation — which does not fill the
+				 * screen — is left where it is.
+				 */}
+				<div aria-hidden className="h-[25vh]" />
 			</ConversationContent>
+			<ScrollToLatest />
 		</Conversation>
 	);
 }

--- a/apps/app/src/components/chat-view.tsx
+++ b/apps/app/src/components/chat-view.tsx
@@ -137,13 +137,12 @@ export function ChatView() {
 					</div>
 				)}
 				{/*
-				 * Room to scroll past the last turn: the tail of the conversation comes
-				 * to rest in the upper three quarters of the screen rather than hard
-				 * against the composer. It is a quarter of the viewport of real
+				 * Room to scroll past the last turn, so the tail of the conversation
+				 * does not come to rest hard against the composer. It is real
 				 * scrollable height, so a short conversation — which does not fill the
 				 * screen — is left where it is.
 				 */}
-				<div aria-hidden className="h-[25vh]" />
+				<div aria-hidden className="h-[10vh]" />
 			</ConversationContent>
 			<ScrollToLatest />
 		</Conversation>

--- a/apps/app/src/lib/chat.tsx
+++ b/apps/app/src/lib/chat.tsx
@@ -125,9 +125,23 @@ export function ChatProvider({ children }: { children: React.ReactNode }) {
 				content: m.content,
 				id: m.id,
 			}));
-			stream.submit({
-				messages: [...history, { type: "human", content: trimmed }],
-			});
+			// The id is named here rather than left to the server: it is this turn's
+			// React key, and the server echoes it back verbatim, so the message shown
+			// on send and the one that comes back are the same row.
+			const turn = [
+				...history,
+				{ type: "human", content: trimmed, id: crypto.randomUUID() },
+			];
+			// Shown optimistically because `submit` first resets the stream's values
+			// to `initialValues` — `{}` for a stateless transport — so without this
+			// the transcript blanks out until the server's opening `values` event
+			// echoes it back. That empty frame collapses the scroll container, which
+			// throws a reader who was part-way up the conversation to the top and
+			// then scrolls them back down once the messages return.
+			stream.submit(
+				{ messages: turn },
+				{ optimisticValues: { messages: turn } },
+			);
 		},
 		stop: () => stream.stop(),
 		clear: () => {

--- a/packages/ui/src/components/ai-elements/conversation.tsx
+++ b/packages/ui/src/components/ai-elements/conversation.tsx
@@ -8,6 +8,11 @@ import { StickToBottom, useStickToBottomContext } from "use-stick-to-bottom";
 import { cn } from "../../lib/utils";
 import { Button } from "../ui/button";
 
+// The container only keeps a view that is *already* at the bottom stuck there,
+// so anything that should pull the reader down from further up — sending a turn,
+// for one — has to ask, and asks through this.
+export { useStickToBottomContext };
+
 export type ConversationProps = ComponentProps<typeof StickToBottom>;
 
 export const Conversation = ({ className, ...props }: ConversationProps) => (


### PR DESCRIPTION
## What

Two changes to how the bottom of the chat behaves.

**The scroll jump on send.** `stream.submit` resets the stream's values to `initialValues` — `{}` for a stateless transport — before the server echoes the new turn back. For one frame the transcript is empty, the scroll container collapses, and a reader who was part-way up the conversation gets thrown to the top and then scrolled back down once the messages return. The turn is now passed as `optimisticValues`, so the container never collapses. Its id is named client-side and echoed back verbatim by the server, so the row shown on send and the row that comes back are the same React key rather than two.

Sending then *deliberately* jumps to the bottom (`StickOnSend`, instant rather than animated — being carried down through the whole transcript is the thing worth avoiding), and a small `latest ▼` button at the foot of the conversation is the way back down for a reader who has travelled up. `useStickToBottomContext` is re-exported from `@repo/ui` for this.

**The gap above the composer.** The trailing spacer was a quarter of the viewport, which left the last message floating well above the input. Now a tenth — still enough that the last line never sits hard against the composer.

## Test plan

- [ ] Scroll part-way up a long conversation, send a turn: the view jumps straight to the bottom with no trip to the top first.
- [ ] Scroll up: `latest ▼` appears above the composer; click it to return to the bottom.
- [ ] The last message rests just above the input, not a quarter-screen above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)