### PR TITLE
refactor(mcp-toolkit): keep only what the Google provider config cann…

### DIFF
--- a/apps/mcp-toolkit/src/google-auth.ts
+++ b/apps/mcp-toolkit/src/google-auth.ts
@@ -49,33 +49,24 @@ function serverKeys(server: string): ServerKeys {
 }
 
 class GoogleOfflineProvider extends GoogleProvider {
-	constructor(
-		config: ConstructorParameters<typeof GoogleProvider>[0],
-		private readonly stateDirectory: string,
-	) {
-		super(config);
-	}
-
 	protected override createProxy(): OAuthProxy {
 		return new OAuthProxy({
+			allowedRedirectUriPatterns: this.config.allowedRedirectUriPatterns,
 			allowPlainPkce: false,
 			baseUrl: this.config.baseUrl,
-			consentRequired: false,
+			consentRequired: this.config.consentRequired ?? true,
 			encryptionKey: this.config.encryptionKey,
 			extraAuthorizationParams: {
 				access_type: "offline",
 				prompt: "consent",
 			},
 			jwtSigningKey: this.config.jwtSigningKey,
-			scopes: this.config.scopes ?? GOOGLE_SCOPES,
-			tokenStorage: new DiskStore({
-				directory: join(this.stateDirectory, "tokens"),
-			}),
-			upstreamAuthorizationEndpoint:
-				"https://accounts.google.com/o/oauth2/v2/auth",
-			upstreamClientId: googleSheetsEnv.GOOGLE_CLIENT_ID,
-			upstreamClientSecret: googleSheetsEnv.GOOGLE_CLIENT_SECRET,
-			upstreamTokenEndpoint: GOOGLE_TOKEN_ENDPOINT,
+			scopes: this.config.scopes ?? this.getDefaultScopes(),
+			tokenStorage: this.config.tokenStorage,
+			upstreamAuthorizationEndpoint: this.getAuthorizationEndpoint(),
+			upstreamClientId: this.config.clientId,
+			upstreamClientSecret: this.config.clientSecret,
+			upstreamTokenEndpoint: this.getTokenEndpoint(),
 		});
 	}
 }
@@ -86,17 +77,16 @@ export function googleProvider(params: {
 }): GoogleProvider {
 	const directory = stateDir(params.server);
 	const keys = serverKeys(params.server);
-	return new GoogleOfflineProvider(
-		{
-			baseUrl: params.baseUrl,
-			clientId: googleSheetsEnv.GOOGLE_CLIENT_ID,
-			clientSecret: googleSheetsEnv.GOOGLE_CLIENT_SECRET,
-			encryptionKey: keys.encryptionKey,
-			jwtSigningKey: keys.jwtSigningKey,
-			scopes: GOOGLE_SCOPES,
-		},
-		directory,
-	);
+	return new GoogleOfflineProvider({
+		baseUrl: params.baseUrl,
+		clientId: googleSheetsEnv.GOOGLE_CLIENT_ID,
+		clientSecret: googleSheetsEnv.GOOGLE_CLIENT_SECRET,
+		consentRequired: false,
+		encryptionKey: keys.encryptionKey,
+		jwtSigningKey: keys.jwtSigningKey,
+		scopes: GOOGLE_SCOPES,
+		tokenStorage: new DiskStore({ directory: join(directory, "tokens") }),
+	});
 }
 
 export function credentialsFrom(

--- a/devdocs/mcp-toolkit.md
+++ b/devdocs/mcp-toolkit.md
@@ -266,8 +266,8 @@ bearing:
   `GoogleProvider` does not send these, and without them Google issues no refresh
   token: the server works for an hour and fails overnight. `prompt=consent` is
   needed as well as `access_type=offline`, because a user who has approved the app
-  before otherwise gets an access token and nothing else. This is the reason
-  `createProxy()` is overridden instead of the provider being used as shipped.
+  before otherwise gets an access token and nothing else. `AuthProviderConfig`
+  has no field for it, which is the reason `createProxy()` is overridden at all.
 - **`tokenStorage: DiskStore`** under `~/.lisptc/sheets/tokens`, so restarting the
   server does not force everyone to authorize again. The default is in-memory.
 - **A persisted `jwtSigningKey` and `encryptionKey`**, written once to
@@ -280,6 +280,12 @@ bearing:
   the interpreter sends S256 anyway. The proxy's own consent screen is off because
   Google is already showing one; two consecutive approval pages for a local dev
   server is friction with nothing behind it.
+
+Only the first and `allowPlainPkce` need the subclass. `tokenStorage`, the two
+keys, `consentRequired` and `scopes` are ordinary `AuthProviderConfig` fields and
+are passed to the constructor in `googleProvider()`, so the override sets only
+what the config cannot reach and otherwise mirrors `GoogleProvider.createProxy()`
+field for field, `allowedRedirectUriPatterns` included.
 
 `allowedRedirectUriPatterns` is deliberately left unset: `fastmcp`'s default is
 `["http://localhost:*", "http://127.0.0.1:*"]`, which is exactly the loopback


### PR DESCRIPTION
…ot reach

extraAuthorizationParams and allowPlainPkce have no AuthProviderConfig field, so createProxy() still has to be overridden for them. tokenStorage, consentRequired, scopes, the client credentials and both endpoints do have one, so they move to the constructor call and the override mirrors the base field for field, restoring the allowedRedirectUriPatterns pass-through it had dropped.