### PR TITLE
feat(ai): name the provider and model in a step's metadata

### DIFF
--- a/apps/app/src/components/message-meta.tsx
+++ b/apps/app/src/components/message-meta.tsx
@@ -6,7 +6,9 @@ export type MetaField =
 	| "steps"
 	| "input"
 	| "cached"
-	| "output";
+	| "output"
+	| "model"
+	| "provider";
 
 const META_FIELDS: Record<MetaField, boolean> = {
 	time: true,
@@ -15,6 +17,8 @@ const META_FIELDS: Record<MetaField, boolean> = {
 	input: true,
 	cached: true,
 	output: true,
+	model: true,
+	provider: true,
 };
 
 function formatDuration(ms: number): string {
@@ -26,6 +30,10 @@ function formatDuration(ms: number): string {
 
 function formatTokens(n: number): string {
 	return n >= 1000 ? `${(n / 1000).toFixed(1)}k` : `${n}`;
+}
+
+function formatModel(model: string): string {
+	return model.slice(model.lastIndexOf("/") + 1);
 }
 
 function formatTime(at: string): string | null {
@@ -66,6 +74,8 @@ const SEGMENTS: {
 				? null
 				: `${formatTokens(m.outputTokens)} out`,
 	},
+	{ field: "model", render: (m) => (m.model ? formatModel(m.model) : null) },
+	{ field: "provider", render: (m) => m.provider ?? null },
 ];
 
 export function MessageMeta({

--- a/apps/app/src/lib/chat.tsx
+++ b/apps/app/src/lib/chat.tsx
@@ -20,6 +20,8 @@ export interface ChatMessage {
 export interface StepMeta {
 	at?: string;
 	durationMs: number;
+	provider?: string;
+	model?: string;
 	inputTokens?: number;
 	outputTokens?: number;
 	cachedInputTokens?: number;
@@ -32,6 +34,10 @@ function num(value: unknown): number | undefined {
 		: undefined;
 }
 
+function text(value: unknown): string | undefined {
+	return typeof value === "string" && value !== "" ? value : undefined;
+}
+
 function parseMeta(value: unknown): StepMeta | undefined {
 	if (!value || typeof value !== "object") return undefined;
 	const raw = value as Record<string, unknown>;
@@ -40,6 +46,8 @@ function parseMeta(value: unknown): StepMeta | undefined {
 	return {
 		at: typeof raw.at === "string" ? raw.at : undefined,
 		durationMs,
+		provider: text(raw.provider),
+		model: text(raw.model),
 		inputTokens: num(raw.inputTokens),
 		outputTokens: num(raw.outputTokens),
 		cachedInputTokens: num(raw.cachedInputTokens),

--- a/devdocs/agent-loop.md
+++ b/devdocs/agent-loop.md
@@ -34,6 +34,13 @@ them across the loop charges the same prompt several times over.
 `steps` is the one exception: it belongs to the turn, not the call, so it hangs
 off the message the reader ends on and nowhere else.
 
+`provider` and `model` are **resolved**, never echoed back from the config. A
+request that pins neither still ran on something, and the point of the field is
+to say what answered — an absent provider on the message would leave a reader
+guessing at a default that moves with an env var. The same resolved pair is what
+the turn's trace reports, so PostHog and the transcript cannot disagree about
+which model was billed.
+
 `cachedInput` is a **subset** of `input`, not an extra. Absent when the provider
 says nothing about caching, which is not the same as a cold prompt. A backend
 that reports no usage simply never produces a usage delta, and the turn goes

--- a/packages/ai/src/provider.ts
+++ b/packages/ai/src/provider.ts
@@ -1,3 +1,3 @@
 export type { ProviderName } from "@repo/shared/providers";
 export type { ModelOptions, Provider } from "./provider/core.ts";
-export { getProvider, providers } from "./provider/registry.ts";
+export { getProvider, providers, resolveModel } from "./provider/registry.ts";

--- a/packages/ai/src/provider/registry.ts
+++ b/packages/ai/src/provider/registry.ts
@@ -1,4 +1,8 @@
-import { DEFAULT_PROVIDER, type ProviderName } from "@repo/shared/providers";
+import {
+	DEFAULT_PROVIDER,
+	type ProviderName,
+	providerSpecs,
+} from "@repo/shared/providers";
 import type { Provider } from "./core.ts";
 import { digitalocean } from "./digitalocean.ts";
 import { fireworks } from "./fireworks.ts";
@@ -16,4 +20,14 @@ export function getProvider(name: ProviderName = DEFAULT_PROVIDER): Provider {
 	const provider = providers[name];
 	if (!provider) throw new Error(`unknown AI provider: ${name}`);
 	return provider;
+}
+
+export function resolveModel(
+	provider: ProviderName = DEFAULT_PROVIDER,
+	model?: string,
+): { provider: ProviderName; model: string } {
+	return {
+		provider,
+		model: model ?? providerSpecs[provider].defaultModel,
+	};
 }

--- a/packages/ai/src/stream.ts
+++ b/packages/ai/src/stream.ts
@@ -6,6 +6,7 @@ import {
 	type TokenUsage,
 } from "./agent.ts";
 import { MAX_STEPS } from "./prompts/lisp.ts";
+import { resolveModel } from "./provider.ts";
 import {
 	evalCode,
 	proseFeedbackContent,
@@ -78,13 +79,14 @@ export function streamChatResponse(
 	if (signal)
 		signal.addEventListener("abort", () => abort.abort(), { once: true });
 
+	const { provider, model } = resolveModel(config?.provider, config?.model);
 	const trace: TraceContext = {
 		threadId: threadId ?? crypto.randomUUID(),
 		turnId: crypto.randomUUID(),
 		distinctId: identity?.distinctId,
 		sessionId: identity?.sessionId,
-		provider: config?.provider,
-		model: config?.model,
+		provider,
+		model,
 	};
 	const tracedConfig: AgentConfig = { ...config, trace };
 	const startedAt = Date.now();
@@ -174,6 +176,8 @@ export function streamChatResponse(
 					const meta: Record<string, unknown> = {
 						at: new Date().toISOString(),
 						durationMs: Date.now() - stepStartedAt,
+						provider,
+						model,
 						...(usage
 							? {
 									inputTokens: usage.input,

--- a/packages/ai/test/stream.test.ts
+++ b/packages/ai/test/stream.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_PROVIDER, providerSpecs } from "@repo/shared/providers";
 import { beforeAll, beforeEach, describe, expect, test, vi } from "vitest";
 import type { AgentDelta } from "../src/agent.ts";
 
@@ -21,6 +22,8 @@ interface WireMessage {
 		meta?: {
 			at?: string;
 			durationMs?: number;
+			provider?: string;
+			model?: string;
 			inputTokens?: number;
 			outputTokens?: number;
 			cachedInputTokens?: number;
@@ -77,6 +80,36 @@ describe("chat stream", () => {
 			outputTokens: 6,
 			cachedInputTokens: 10,
 			steps: 2,
+		});
+	});
+
+	test("every model call names the model that was billed for it", async () => {
+		const messages = await finalMessages(
+			streamChatResponse(
+				{ messages: [{ type: "human", content: "what is 1 + 2?" }] },
+				{ provider: "fireworks", model: "a-pinned-one" },
+			),
+		);
+
+		for (const m of messages.filter((m) => m.type === "ai"))
+			expect(m.additional_kwargs?.meta).toMatchObject({
+				provider: "fireworks",
+				model: "a-pinned-one",
+			});
+	});
+
+	test("an unpinned call names the default it actually ran on", async () => {
+		const messages = await finalMessages(
+			streamChatResponse({
+				messages: [{ type: "human", content: "what is 1 + 2?" }],
+			}),
+		);
+
+		expect(
+			messages.find((m) => m.type === "ai")?.additional_kwargs?.meta,
+		).toMatchObject({
+			provider: DEFAULT_PROVIDER,
+			model: providerSpecs[DEFAULT_PROVIDER].defaultModel,
 		});
 	});
 


### PR DESCRIPTION
A step's `additional_kwargs.meta` already carried the time and the token counts.
It did not say what answered the call, so a transcript could not tell a Fireworks
turn from a DigitalOcean one.

## What changed

- `resolveModel(provider?, model?)` (`packages/ai/src/provider/registry.ts`) turns
  an optional config pair into the pair a call actually runs on: the provider
  falls back to `DEFAULT_PROVIDER`, the model to that provider's `defaultModel`.
- `streamChatResponse` resolves once per turn and puts `provider` / `model` in
  every assistant step's `meta`, beside `durationMs`, `inputTokens` and
  `outputTokens`. The same resolved pair now feeds the `TraceContext`, which used
  to pass the unresolved config straight through, so `$ai_provider` / `$ai_model`
  are filled in even when the request pinned neither.
- The web client parses both off the message (`StepMeta`) and the meta strip
  renders them as two more segments, the model shown by its last path segment so
  `accounts/fireworks/models/kimi-k3` reads as `kimi-k3`.
- `devdocs/agent-loop.md` records why the fields are resolved rather than echoed.

## Testing

`pnpm typecheck`, `pnpm lint`, `pnpm check:comments`, `pnpm knip`, `pnpm test` all
pass. Two new cases in `packages/ai/test/stream.test.ts`: a pinned call reports
what it was pinned to, an unpinned one reports the default it actually ran on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
